### PR TITLE
refactor: 调整目录限制，优化处理逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,22 +59,25 @@ _✨ 基于 **[Vue](https://github.com/vuejs/vue)** 和 **[FastAPI](https://gith
 | 可执行文件名 | MWU               | 暂不可修改                                                   |
 | LOGO         |                         | 暂不可修改                                                   |
 
-### 📦 额外拓展功能
+### 📁 路径规范
 
-#### 📁 路径规范（重要）
+所有路径统一按软件根目录解析，软件根目录定义为 `mwu.exe` 所在目录。
 
-为简化路径处理，所有在 `interface.json` 与其导入片段中出现的资源文件路径，统一使用 `resource/...` 形式：
-
-- `resource[].path` 中的每一项必须以 `resource/` 开头
-- `import` 中的每一项必须以 `resource/` 开头
-- 任务与 pipeline 相关文档路径（如 `description` / `doc` / `desc` 中填写的 Markdown/文本文件路径）必须以 `resource/` 开头
+- 路径必须是根目录相对路径
+- 禁止使用 `./` 或 `../`
+- 禁止越界访问软件根目录之外的文件
 
 示例：
 
 - 正确：`resource/tasks/preset/Daily.json`
-- 正确：`resource/announcement/1.简介.md`
+- 正确：`config/maa_option.json`
+- 正确：`tasks/登录.json`
 - 错误：`./resource/tasks/preset/Daily.json`
-- 错误：`tasks/preset/Daily.json`
+- 错误：`../resource/Daily.json`
+- 错误：`../../../../resource/Daily.json`
+
+
+### 📦 额外拓展功能
 
 #### scan_select 选项类型
 
@@ -87,7 +90,7 @@ _✨ 基于 **[Vue](https://github.com/vuejs/vue)** 和 **[FastAPI](https://gith
 | `type` | `"scan_select"` | 是 | 选项类型 |
 | `label` | `string` | 否 | 前端显示名称 |
 | `description` | `string` | 否 | 描述信息 |
-| `scan_dir` | `string` | 是 | 扫描目录。必须以 `resource/` 开头，路径基于 interface.json 所在目录解析，并做越界限制（不允许跳出该目录） |
+| `scan_dir` | `string` | 是 | 扫描目录，路径基于软件根目录解析 |
 | `scan_filter` | `string` | 是 | `glob pattern`，用于筛选文件，如 `**/*.json` |
 | `pipeline_override` | `object` | 是 | 任务执行时使用的覆盖配置，必须在任意层级的 `attach` 中至少包含一次当前选项名键（如 `attach.bbc_team_config`） |
 | `cases` | `OptionCase[]` | 否（配置阶段应省略或空数组） | 加载时自动生成，`name`/`label` 均为相对 `scan_dir` 的路径+文件名 |

--- a/front/src/components/panel/common/MarkdownViewer.vue
+++ b/front/src/components/panel/common/MarkdownViewer.vue
@@ -32,10 +32,11 @@ const render = new marked.Renderer()
 
 render.image = function ({ href, title, text }: Tokens.Image) {
   const rawHref = href || ""
-  const safeHref =
+  const resolvedHref =
     rawHref && !isExternalUrl(rawHref) && !rawHref.startsWith("/")
       ? buildResourceUrl(rawHref)
       : rawHref
+  const safeHref = resolvedHref || "data:,"
   const titleAttr = title ? ` title="${title}"` : ""
   const altAttr = text ? ` alt="${text}"` : ""
   return `<img src="${safeHref}"${titleAttr}${altAttr} class="preview-image" style="max-width: 100%; object-fit: contain; cursor: pointer;" />`

--- a/front/src/utils/interface/content.ts
+++ b/front/src/utils/interface/content.ts
@@ -1,6 +1,8 @@
 import type { InterfaceModel } from "@/types/interface/model"
+import { showGlobalMessage } from "@/services/feedback/message"
 
 const textFilePattern = /^(?:\.\/)?(?:[^/]+[/])*[^/]+\.(?:md|markdown|txt|html?)$/i
+const invalidPathNotified = new Set<string>()
 
 export function isExternalUrl(value: string): boolean {
   return /^(?:https?:)?\/\//i.test(value) || /^(?:data|blob):/i.test(value)
@@ -9,21 +11,32 @@ export function isExternalUrl(value: string): boolean {
 function normalizeRootRelativePath(path: string): string | undefined {
   const normalizedPath = path.trim().replace(/\\/g, "/")
   if (!normalizedPath) {
+    notifyInvalidPath(path, "路径不能为空")
     return undefined
   }
 
   const parts = normalizedPath.split("/")
   if (parts.some((part) => part.length === 0 || part === "." || part === "..")) {
+    notifyInvalidPath(path, "禁止使用 . 或 .. 路径段")
     return undefined
   }
 
   return parts.join("/")
 }
 
-export function buildResourceUrl(path: string): string {
+function notifyInvalidPath(path: string, reason: string): void {
+  const key = `${path}::${reason}`
+  if (invalidPathNotified.has(key)) {
+    return
+  }
+  invalidPathNotified.add(key)
+  showGlobalMessage("error", `资源路径不合法: ${path || "(空)"}，${reason}`)
+}
+
+export function buildResourceUrl(path: string): string | undefined {
   const normalizedPath = normalizeRootRelativePath(path)
   if (!normalizedPath) {
-    return ""
+    return undefined
   }
 
   if (normalizedPath === "resource" || normalizedPath.startsWith("resource/")) {
@@ -63,7 +76,7 @@ export function resolveInterfaceAssetUrl(
     return resolvedValue
   }
   const url = buildResourceUrl(resolvedValue)
-  return url || undefined
+  return url
 }
 
 export async function resolveInterfaceDocumentContent(

--- a/front/src/utils/interface/content.ts
+++ b/front/src/utils/interface/content.ts
@@ -3,6 +3,7 @@ import { showGlobalMessage } from "@/services/feedback/message"
 
 const textFilePattern = /^(?:\.\/)?(?:[^/]+[/])*[^/]+\.(?:md|markdown|txt|html?)$/i
 const invalidPathNotified = new Set<string>()
+const windowsDrivePattern = /^[A-Za-z]:/
 
 export function isExternalUrl(value: string): boolean {
   return /^(?:https?:)?\/\//i.test(value) || /^(?:data|blob):/i.test(value)
@@ -12,6 +13,26 @@ function normalizeRootRelativePath(path: string): string | undefined {
   const normalizedPath = path.trim().replace(/\\/g, "/")
   if (!normalizedPath) {
     notifyInvalidPath(path, "路径不能为空")
+    return undefined
+  }
+
+  if (normalizedPath.startsWith("//")) {
+    notifyInvalidPath(path, "不允许使用 UNC 或双斜杠开头路径")
+    return undefined
+  }
+
+  if (normalizedPath.startsWith("/")) {
+    notifyInvalidPath(path, "不允许使用绝对路径")
+    return undefined
+  }
+
+  if (windowsDrivePattern.test(normalizedPath)) {
+    notifyInvalidPath(path, "不允许使用 Windows 盘符路径")
+    return undefined
+  }
+
+  if (normalizedPath.includes(":")) {
+    notifyInvalidPath(path, "不允许包含冒号(:)")
     return undefined
   }
 

--- a/front/src/utils/interface/content.ts
+++ b/front/src/utils/interface/content.ts
@@ -6,15 +6,31 @@ export function isExternalUrl(value: string): boolean {
   return /^(?:https?:)?\/\//i.test(value) || /^(?:data|blob):/i.test(value)
 }
 
-export function buildResourceUrl(path: string): string {
-  const normalizedPath = path.trim().replace(/\\/g, "/").replace(/^\.\//, "")
-  if (normalizedPath === "/resource" || normalizedPath.startsWith("/resource/")) {
-    return normalizedPath
+function normalizeRootRelativePath(path: string): string | undefined {
+  const normalizedPath = path.trim().replace(/\\/g, "/")
+  if (!normalizedPath) {
+    return undefined
   }
+
+  const parts = normalizedPath.split("/")
+  if (parts.some((part) => part.length === 0 || part === "." || part === "..")) {
+    return undefined
+  }
+
+  return parts.join("/")
+}
+
+export function buildResourceUrl(path: string): string {
+  const normalizedPath = normalizeRootRelativePath(path)
+  if (!normalizedPath) {
+    return ""
+  }
+
   if (normalizedPath === "resource" || normalizedPath.startsWith("resource/")) {
     return `/${normalizedPath}`
   }
-  return normalizedPath
+
+  return `/api/file?path=${encodeURIComponent(normalizedPath)}`
 }
 
 export function resolveInterfaceText(
@@ -46,7 +62,8 @@ export function resolveInterfaceAssetUrl(
   if (isExternalUrl(resolvedValue)) {
     return resolvedValue
   }
-  return buildResourceUrl(resolvedValue)
+  const url = buildResourceUrl(resolvedValue)
+  return url || undefined
 }
 
 export async function resolveInterfaceDocumentContent(
@@ -69,6 +86,9 @@ export async function resolveInterfaceDocumentContent(
   }
 
   const url = buildResourceUrl(trimmedValue)
+  if (!url) {
+    return resolvedValue
+  }
 
   try {
     const response = await fetch(url)

--- a/maa_utils.py
+++ b/maa_utils.py
@@ -32,7 +32,7 @@ class MaaWorker:
         interface: InterfaceModel,
         app_root_dir: Path,
     ):
-        Toolkit.init_option("./")
+        Toolkit.init_option(str(app_root_dir))
 
         self.interface = interface
         self.message_conn = message_conn

--- a/maa_utils.py
+++ b/maa_utils.py
@@ -26,7 +26,12 @@ resource.set_cpu()
 
 
 class MaaWorker:
-    def __init__(self, message_conn: SimpleQueue, interface: InterfaceModel):
+    def __init__(
+        self,
+        message_conn: SimpleQueue,
+        interface: InterfaceModel,
+        app_root_dir: Path,
+    ):
         Toolkit.init_option("./")
 
         self.interface = interface
@@ -35,9 +40,7 @@ class MaaWorker:
         self.tasker = Tasker()
         self.http_client = httpx.Client(timeout=30)
 
-        self.context = WorkerContext(
-            interface_base_dir=Path("interface.json").resolve().parent
-        )
+        self.context = WorkerContext(interface_base_dir=app_root_dir.resolve())
         self.device_state = DeviceRuntimeState()
         self.task_state = TaskRuntimeState()
         self.agent_state = AgentRuntimeState()

--- a/main.py
+++ b/main.py
@@ -41,7 +41,18 @@ from services.update_service import (
     get_platform_info,
 )
 
-INTERFACE_PATH = Path("interface.json").resolve()
+
+def _resolve_app_root_dir() -> Path:
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable).resolve().parent
+    return Path(__file__).resolve().parent
+
+
+APP_ROOT_DIR = _resolve_app_root_dir()
+CONFIG_DIR = APP_ROOT_DIR / "config"
+SETTINGS_FILE = CONFIG_DIR / "settings.json"
+TASK_CONFIG_FILE = CONFIG_DIR / "task_config.json"
+INDEX_FILE = APP_ROOT_DIR / "page/index.html"
 
 
 def load_interface_translations() -> dict[str, dict]:
@@ -51,7 +62,7 @@ def load_interface_translations() -> dict[str, dict]:
             raise InterfaceLoadError(f"languages[{locale}] 必须是非空字符串")
 
         resolved_path = resolve_interface_relative_path(
-            INTERFACE_PATH.parent,
+            APP_ROOT_DIR,
             relative_path,
             field_name=f"languages[{locale}]",
         )
@@ -71,7 +82,7 @@ def load_interface_translations() -> dict[str, dict]:
 
 
 try:
-    interface = load_interface_model(INTERFACE_PATH)
+    interface = load_interface_model(APP_ROOT_DIR)
     interface_translations = load_interface_translations()
 except Exception as e:
     print(e)
@@ -85,11 +96,11 @@ class ScanSelectRescanRequest(BaseModel):
     option_name: str
 
 
-if not os.path.exists("config"):
-    os.makedirs("config")
-    with open("config/settings.json", "w", encoding="utf-8") as f:
+if not CONFIG_DIR.exists():
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    with SETTINGS_FILE.open("w", encoding="utf-8") as f:
         json.dump(SettingsModel().model_dump(), f, indent=4, ensure_ascii=False)
-    with open("config/task_config.json", "w", encoding="utf-8") as f:
+    with TASK_CONFIG_FILE.open("w", encoding="utf-8") as f:
         json.dump(TaskConfigModel().model_dump(), f, indent=4, ensure_ascii=False)
 
 
@@ -109,9 +120,9 @@ async def log_monitor():
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     app_state.is_shutting_down = False
-    app_state.worker = MaaWorker(app_state.message_conn, interface)
+    app_state.worker = MaaWorker(app_state.message_conn, interface, APP_ROOT_DIR)
     app_state.broadcaster = LogBroadcaster()
-    with open("config/settings.json", "r", encoding="utf-8") as f:
+    with SETTINGS_FILE.open("r", encoding="utf-8") as f:
         config_data = json.load(f)
     app_state.settings = SettingsModel(**config_data)
     # 初始化调度器
@@ -134,16 +145,15 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
-app.mount("/assets", StaticFiles(directory="page/assets"))
-app.mount("/resource", StaticFiles(directory="resource"))
+app.mount("/assets", StaticFiles(directory=str(APP_ROOT_DIR / "page/assets")))
+app.mount("/resource", StaticFiles(directory=str(APP_ROOT_DIR / "resource")))
 
 
 def _load_normalized_task_config() -> tuple[TaskConfigModel, bool]:
-    config_path = "config/task_config.json"
-    config_exists = os.path.exists(config_path)
+    config_exists = TASK_CONFIG_FILE.exists()
 
     if config_exists:
-        with open(config_path, "r", encoding="utf-8") as f:
+        with TASK_CONFIG_FILE.open("r", encoding="utf-8") as f:
             config_data = json.load(f)
     else:
         config_data = TaskConfigModel().model_dump()
@@ -154,7 +164,7 @@ def _load_normalized_task_config() -> tuple[TaskConfigModel, bool]:
 
     should_write_back = (not config_exists) or config_data != normalized_data
     if should_write_back:
-        with open(config_path, "w", encoding="utf-8") as f:
+        with TASK_CONFIG_FILE.open("w", encoding="utf-8") as f:
             json.dump(normalized_data, f, indent=4, ensure_ascii=False)
 
     return normalized_config, should_write_back
@@ -168,13 +178,26 @@ async def spa_middleware(request: Request, call_next):
         or request.url.path.startswith("/assets/")
         or request.url.path.startswith("/resource/")
     ):
-        return FileResponse("page/index.html")
+        return FileResponse(INDEX_FILE)
     return response
 
 
 @app.get("/")
 async def serve_homepage():
-    return FileResponse("page/index.html")
+    return FileResponse(INDEX_FILE)
+
+
+@app.get("/api/file")
+def get_file(path: str):
+    try:
+        resolved_path = resolve_interface_relative_path(
+            APP_ROOT_DIR,
+            path,
+            field_name="path",
+        )
+    except InterfaceLoadError as exc:
+        return {"status": "failed", "message": str(exc)}
+    return FileResponse(resolved_path)
 
 
 @app.get("/api/interface")
@@ -194,9 +217,7 @@ def rescan_scan_select(payload: ScanSelectRescanRequest):
 
     try:
         with interface_lock:
-            cases = rescan_scan_select_option(
-                interface, option_name, INTERFACE_PATH.parent
-            )
+            cases = rescan_scan_select_option(interface, option_name, APP_ROOT_DIR)
     except InterfaceLoadError as exc:
         return {"status": "failed", "message": str(exc)}
     except Exception as exc:
@@ -311,7 +332,7 @@ async def set_resource(name: str):
 
 @app.get("/api/settings")
 def get_settings():
-    with open("config/settings.json", "r", encoding="utf-8") as f:
+    with SETTINGS_FILE.open("r", encoding="utf-8") as f:
         config_data = json.load(f)
     app_state.settings = SettingsModel(**config_data)
     return {"status": "success", "settings": app_state.settings.model_dump()}
@@ -319,7 +340,7 @@ def get_settings():
 
 @app.post("/api/settings")
 def set_settings(settings: SettingsModel):
-    with open("config/settings.json", "w", encoding="utf-8") as f:
+    with SETTINGS_FILE.open("w", encoding="utf-8") as f:
         json.dump(settings.model_dump(), f, indent=4, ensure_ascii=False)
     app_state.settings = settings
     return {"status": "success"}
@@ -339,7 +360,7 @@ def get_task_config():
 def save_task_config(config: TaskConfigModel):
     try:
         normalized_config = normalize_task_config(config, interface)
-        with open("config/task_config.json", "w", encoding="utf-8") as f:
+        with TASK_CONFIG_FILE.open("w", encoding="utf-8") as f:
             json.dump(normalized_config.model_dump(), f, indent=4, ensure_ascii=False)
         return {"status": "success"}
     except Exception as e:
@@ -350,9 +371,8 @@ def save_task_config(config: TaskConfigModel):
 @app.delete("/api/task-config")
 def reset_task_config():
     try:
-        config_path = "config/task_config.json"
-        if os.path.exists(config_path):
-            os.remove(config_path)
+        if TASK_CONFIG_FILE.exists():
+            TASK_CONFIG_FILE.unlink()
         return {"status": "success"}
     except Exception as e:
         app_state.send_log(f"重置任务配置失败: {e}")

--- a/main.py
+++ b/main.py
@@ -195,7 +195,7 @@ def get_file(path: str):
             path,
             field_name="path",
         )
-    except InterfaceLoadError as exc:
+    except ValueError as exc:
         message = str(exc)
         status_code = 404 if ("不存在" in message or "不是文件" in message) else 400
         return JSONResponse(

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import uvicorn
 from fastapi import FastAPI, Request
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
@@ -196,7 +196,12 @@ def get_file(path: str):
             field_name="path",
         )
     except InterfaceLoadError as exc:
-        return {"status": "failed", "message": str(exc)}
+        message = str(exc)
+        status_code = 404 if ("不存在" in message or "不是文件" in message) else 400
+        return JSONResponse(
+            status_code=status_code,
+            content={"status": "failed", "message": message},
+        )
     return FileResponse(resolved_path)
 
 

--- a/models/interface_loader.py
+++ b/models/interface_loader.py
@@ -166,54 +166,52 @@ def _merge_fragment_sections(
         target["preset"].extend(copy.deepcopy(presets))
 
 
+def _normalize_root_relative_path(raw_path: str, *, field_name: str) -> str:
+    normalized_path = raw_path.strip().replace("\\", "/")
+    if not normalized_path:
+        raise InterfaceLoadError(f"{field_name} 不能为空")
+
+    candidate = Path(normalized_path)
+    if candidate.is_absolute() or candidate.drive or candidate.root:
+        raise InterfaceLoadError(f"{field_name} 不允许使用绝对路径: {raw_path}")
+
+    if normalized_path in {".", ".."}:
+        raise InterfaceLoadError(f"{field_name} 不允许包含 . 或 .. 路径段: {raw_path}")
+
+    parts = normalized_path.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise InterfaceLoadError(f"{field_name} 不允许包含 . 或 .. 路径段: {raw_path}")
+
+    return "/".join(parts)
+
+
 def _resolve_import_path(import_path: str, base_dir: Path) -> Path:
-    path = Path(import_path)
-    if not path.is_absolute():
-        path = base_dir / path
-    return path.resolve()
-
-
-def _contains_parent_segment(path_value: str) -> bool:
-    return any(part == ".." for part in Path(path_value).parts)
+    normalized_import_path = _normalize_root_relative_path(
+        import_path,
+        field_name="import",
+    )
+    resolved_path = (base_dir / normalized_import_path).resolve()
+    try:
+        resolved_path.relative_to(base_dir)
+    except ValueError as exc:
+        raise InterfaceLoadError(
+            f"import 越界，禁止访问软件根目录之外的路径: {import_path}"
+        ) from exc
+    return resolved_path
 
 
 def _validate_scan_dir(scan_dir: str, option_name: str) -> str:
-    normalized_scan_dir = scan_dir.strip()
-    normalized_scan_dir_posix = normalized_scan_dir.replace("\\", "/")
-
-    if not normalized_scan_dir_posix.startswith("resource/"):
-        raise InterfaceLoadError(
-            f"scan_select 选项 {option_name} 的 scan_dir 必须以 resource/ 开头"
-        )
-
-    scan_dir_path = Path(normalized_scan_dir)
-    if scan_dir_path.is_absolute() or scan_dir_path.drive or scan_dir_path.root:
-        raise InterfaceLoadError(
-            f"scan_select 选项 {option_name} 的 scan_dir 不允许使用绝对路径"
-        )
-    if _contains_parent_segment(normalized_scan_dir):
-        raise InterfaceLoadError(
-            f"scan_select 选项 {option_name} 的 scan_dir 不允许包含父级目录跳转"
-        )
-    return normalized_scan_dir
+    return _normalize_root_relative_path(
+        scan_dir,
+        field_name=f"scan_select 选项 {option_name} 的 scan_dir",
+    )
 
 
 def _validate_scan_filter(scan_filter: str, option_name: str) -> str:
-    normalized_scan_filter = scan_filter.strip()
-    scan_filter_path = Path(normalized_scan_filter)
-    if (
-        scan_filter_path.is_absolute()
-        or scan_filter_path.drive
-        or scan_filter_path.root
-    ):
-        raise InterfaceLoadError(
-            f"scan_select 选项 {option_name} 的 scan_filter 不允许使用绝对路径"
-        )
-    if _contains_parent_segment(normalized_scan_filter):
-        raise InterfaceLoadError(
-            f"scan_select 选项 {option_name} 的 scan_filter 不允许包含父级目录跳转"
-        )
-    return normalized_scan_filter
+    return _normalize_root_relative_path(
+        scan_filter,
+        field_name=f"scan_select 选项 {option_name} 的 scan_filter",
+    )
 
 
 def _is_within_base_dir(path: Path, base_dir: Path) -> bool:
@@ -231,21 +229,11 @@ def resolve_interface_relative_path(
     field_name: str = "path",
     allow_directories: bool = False,
 ) -> Path:
-    normalized_path = raw_path.strip()
-    if not normalized_path:
-        raise InterfaceLoadError(f"{field_name} 不能为空")
-
-    candidate = Path(normalized_path)
-    if candidate.is_absolute() or candidate.drive or candidate.root:
-        raise InterfaceLoadError(f"{field_name} 不允许使用绝对路径: {raw_path}")
-    if _contains_parent_segment(normalized_path):
-        raise InterfaceLoadError(f"{field_name} 不允许包含父级目录跳转: {raw_path}")
+    normalized_path = _normalize_root_relative_path(raw_path, field_name=field_name)
 
     resolved_path = (base_dir / normalized_path).resolve()
     if not _is_within_base_dir(resolved_path, base_dir):
-        raise InterfaceLoadError(
-            f"{field_name} 越界，禁止访问 interface.json 目录之外的路径"
-        )
+        raise InterfaceLoadError(f"{field_name} 越界，禁止访问软件根目录之外的路径")
     if not resolved_path.exists():
         raise InterfaceLoadError(f"{field_name} 不存在: {raw_path}")
     if allow_directories:
@@ -290,7 +278,7 @@ def _scan_scan_select_cases(
     resolved_scan_dir = (base_dir / normalized_scan_dir).resolve()
     if not _is_within_base_dir(resolved_scan_dir, base_dir):
         raise InterfaceLoadError(
-            f"scan_select 选项 {option_name} 的 scan_dir 越界，禁止访问 interface.json 目录之外的路径"
+            f"scan_select 选项 {option_name} 的 scan_dir 越界，禁止访问软件根目录之外的路径"
         )
     if not resolved_scan_dir.exists() or not resolved_scan_dir.is_dir():
         raise InterfaceLoadError(
@@ -476,15 +464,19 @@ def _merge_imports_into_target(
         _merge_imports_into_target(
             target,
             child_imports,
-            resolved_path.parent,
+            base_dir,
             state,
             [*stack, resolved_path],
         )
         _merge_fragment_sections(target, fragment, resolved_path, state)
 
 
-def load_interface_model(interface_path: str | Path) -> InterfaceModel:
-    root_path = Path(interface_path).resolve()
+def load_interface_model(base_dir: str | Path) -> InterfaceModel:
+    resolved_base_dir = Path(base_dir).resolve()
+    root_path = (resolved_base_dir / "interface.json").resolve()
+    if not _is_within_base_dir(root_path, resolved_base_dir):
+        raise InterfaceLoadError("interface.json 不在软件根目录内")
+
     root_data = _read_json_dict(root_path)
     merged_data = copy.deepcopy(root_data)
     merge_state = _MergeState()
@@ -494,11 +486,11 @@ def load_interface_model(interface_path: str | Path) -> InterfaceModel:
     _merge_imports_into_target(
         merged_data,
         root_imports,
-        root_path.parent,
+        resolved_base_dir,
         merge_state,
         [root_path],
     )
-    _expand_scan_select_options(merged_data, root_path.parent)
+    _expand_scan_select_options(merged_data, resolved_base_dir)
 
     try:
         interface_model = InterfaceModel.model_validate(merged_data)

--- a/models/interface_loader.py
+++ b/models/interface_loader.py
@@ -169,18 +169,18 @@ def _merge_fragment_sections(
 def _normalize_root_relative_path(raw_path: str, *, field_name: str) -> str:
     normalized_path = raw_path.strip().replace("\\", "/")
     if not normalized_path:
-        raise InterfaceLoadError(f"{field_name} 不能为空")
+        raise ValueError(f"{field_name} 不能为空")
 
     candidate = Path(normalized_path)
     if candidate.is_absolute() or candidate.drive or candidate.root:
-        raise InterfaceLoadError(f"{field_name} 不允许使用绝对路径: {raw_path}")
+        raise ValueError(f"{field_name} 不允许使用绝对路径: {raw_path}")
 
     if normalized_path in {".", ".."}:
-        raise InterfaceLoadError(f"{field_name} 不允许包含 . 或 .. 路径段: {raw_path}")
+        raise ValueError(f"{field_name} 不允许包含 . 或 .. 路径段: {raw_path}")
 
     parts = normalized_path.split("/")
     if any(part in {"", ".", ".."} for part in parts):
-        raise InterfaceLoadError(f"{field_name} 不允许包含 . 或 .. 路径段: {raw_path}")
+        raise ValueError(f"{field_name} 不允许包含 . 或 .. 路径段: {raw_path}")
 
     return "/".join(parts)
 
@@ -194,7 +194,7 @@ def _resolve_import_path(import_path: str, base_dir: Path) -> Path:
     try:
         resolved_path.relative_to(base_dir)
     except ValueError as exc:
-        raise InterfaceLoadError(
+        raise ValueError(
             f"import 越界，禁止访问软件根目录之外的路径: {import_path}"
         ) from exc
     return resolved_path
@@ -233,14 +233,14 @@ def resolve_interface_relative_path(
 
     resolved_path = (base_dir / normalized_path).resolve()
     if not _is_within_base_dir(resolved_path, base_dir):
-        raise InterfaceLoadError(f"{field_name} 越界，禁止访问软件根目录之外的路径")
+        raise ValueError(f"{field_name} 越界，禁止访问软件根目录之外的路径: {raw_path}")
     if not resolved_path.exists():
-        raise InterfaceLoadError(f"{field_name} 不存在: {raw_path}")
+        raise ValueError(f"{field_name} 不存在: {raw_path}")
     if allow_directories:
         if not resolved_path.is_dir():
-            raise InterfaceLoadError(f"{field_name} 不是目录: {raw_path}")
+            raise ValueError(f"{field_name} 不是目录: {raw_path}")
     elif not resolved_path.is_file():
-        raise InterfaceLoadError(f"{field_name} 不是文件: {raw_path}")
+        raise ValueError(f"{field_name} 不是文件: {raw_path}")
     return resolved_path
 
 


### PR DESCRIPTION
## Summary by Sourcery

围绕应用程序根目录统一路径处理方式，并收紧对界面资源和导入路径的校验。

New Features:
- 暴露一个后端 API 端点，用于在应用程序根目录下为界面内容引用的文件提供服务。

Bug Fixes:
- 禁止界面导入、目录扫描和过滤器使用绝对路径或父目录片段，避免发生越出软件根目录的路径遍历。
- 确保在加载前，`interface.json` 必须位于应用程序根目录之内。

Enhancements:
- 将路径规范化和校验重构到一个共享的辅助工具中，在 `import`、`scan_dir`、`scan_filter` 和基于界面相对路径的解析中复用。
- 将所有后端路径、静态挂载以及 worker 上下文都基于一个计算得到的应用程序根目录，而不是硬编码的相对路径。
- 使前端资源 URL 构建方式与新的后端文件服务端点和更严格的路径规则保持一致，当路径无效时返回空值或 `undefined`。
- 更新 README 文档，描述新的相对于根目录的路径规则以及 `scan_select` 路径语义。

Documentation:
- 阐明路径指定规则为相对于软件目录的根路径，并记录更新后的 `scan_select` 和 `scan_dir` 行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify path handling around the application root directory and tighten path validation for interface resources and imports.

New Features:
- Expose a backend API endpoint to serve files referenced by interface content under the application root.

Bug Fixes:
- Prevent interface imports, scan directories, and filters from using absolute paths or parent directory segments, avoiding traversal outside the software root.
- Ensure interface.json must reside within the application root directory before loading.

Enhancements:
- Refactor path normalization and validation into a shared helper used across import, scan_dir, scan_filter, and interface-relative resolution.
- Base all backend paths, static mounts, and worker context on a computed application root directory instead of hardcoded relative paths.
- Align frontend resource URL building with the new backend file-serving endpoint and stricter path rules, returning empty or undefined when paths are invalid.
- Update README documentation to describe the new root-relative path rules and scan_select path semantics.

Documentation:
- Clarify path specification rules to be root-relative to the software directory and document updated scan_select scan_dir behavior.

</details>