### PR TITLE
feat(sink/focus): 支持sink和focus协议

### DIFF
--- a/app_state.py
+++ b/app_state.py
@@ -1,6 +1,7 @@
 import asyncio
 import subprocess
 import time
+from collections import deque
 from queue import SimpleQueue
 from typing import Any
 
@@ -10,11 +11,14 @@ from models.settings import SettingsModel
 from scheduler_manager import SchedulerManager
 
 
+_HISTORY_MAXLEN = 2000
+
+
 class LogBroadcaster:
     def __init__(self):
         self._queues: list[asyncio.Queue] = []
 
-    def add_client(self, history: list[RealtimeEvent]) -> asyncio.Queue:
+    def add_client(self, history: deque[RealtimeEvent]) -> asyncio.Queue:
         q = asyncio.Queue()
         for message in history:
             q.put_nowait(message.model_copy(update={"notify": False}))
@@ -59,7 +63,7 @@ class AppState:
         self.message_conn = SimpleQueue()
         self.worker: MaaWorker | None = None
         self.is_shutting_down = False
-        self.history_message: list[RealtimeEvent] = []
+        self.history_message: deque[RealtimeEvent] = deque(maxlen=_HISTORY_MAXLEN)
         self.current_status = None
         self.broadcaster: LogBroadcaster | None = None
         self.scheduler_manager: SchedulerManager | None = None

--- a/app_state.py
+++ b/app_state.py
@@ -21,7 +21,7 @@ class LogBroadcaster:
     def add_client(self, history: deque[RealtimeEvent]) -> asyncio.Queue:
         q = asyncio.Queue()
         for message in history:
-            q.put_nowait(message.model_copy(update={"notify": False}))
+            q.put_nowait(message.model_copy(update={"notify": []}))
         self._queues.append(q)
         return q
 
@@ -40,7 +40,7 @@ def build_log_event(msg: str, level: RealtimeEventLevel = "info") -> RealtimeEve
         level=level,
         message=msg,
         time=time.strftime("%Y-%m-%d %H:%M:%S", time.localtime()),
-        notify=False,
+        notify=[],
     )
 
 
@@ -54,7 +54,7 @@ def normalize_event(payload: RealtimeEvent | dict[str, Any] | str) -> RealtimeEv
         level="info",
         message=payload,
         time="",
-        notify=False,
+        notify=[],
     )
 
 

--- a/front/src/app/main.ts
+++ b/front/src/app/main.ts
@@ -10,6 +10,7 @@ import {
   formatRealtimeLog,
   showBrowserRealtimeNotification,
   showRealtimeMessage,
+  showToastMessage,
 } from "@/services/realtime/events"
 import type { RealtimeEvent } from "@/types/realtime/model"
 import "virtual:uno.css"
@@ -24,20 +25,43 @@ const indexStore = useIndexStore(pinia)
 const settingsStore = useSettingsStore(pinia)
 
 function handleRealtimeEvent(data: RealtimeEvent): void {
-  indexStore.UpdateLog(formatRealtimeLog(data))
+  const display = data.display ?? ["log"]
+
+  if (display.includes("log")) {
+    indexStore.UpdateLog(formatRealtimeLog(data))
+  }
+  if (display.includes("toast")) {
+    showToastMessage(data)
+  }
+  if (display.includes("notification") && data.notify) {
+    showBrowserRealtimeNotification(data, settingsStore.settings.notification)
+  }
 
   if (!data.notify) {
     return
   }
 
   showRealtimeMessage(data)
-  showBrowserRealtimeNotification(data, settingsStore.settings.notification)
 }
 
-;(["log", "task.started", "task.completed", "task.failed", "notification.test"] as const).forEach(
-  (eventName) => {
-    sse.addEventListener(eventName, handleRealtimeEvent)
-  },
-)
+/** 所有 SSE 事件类型（保持兼容：非 sink 事件仍独立触发 handleRealtimeEvent） */
+;(
+  [
+    "log",
+    "focus.display",
+    "task.started",
+    "task.completed",
+    "task.failed",
+    "notification.test",
+    "resource.loading",
+    "controller.action",
+    "tasker.task",
+    "node.recognition",
+    "node.action",
+    "sink",
+  ] as const
+).forEach((eventName) => {
+  sse.addEventListener(eventName, handleRealtimeEvent)
+})
 
 app.mount("#app")

--- a/front/src/app/main.ts
+++ b/front/src/app/main.ts
@@ -25,19 +25,17 @@ const indexStore = useIndexStore(pinia)
 const settingsStore = useSettingsStore(pinia)
 
 function handleRealtimeEvent(data: RealtimeEvent): void {
-  const display = data.display ?? ["log"]
-
-  if (display.includes("log")) {
+  if (data.display) {
     indexStore.UpdateLog(formatRealtimeLog(data))
   }
-  if (display.includes("toast")) {
+  if (data.notify.includes("toast")) {
     showToastMessage(data)
   }
-  if (display.includes("notification") && data.notify) {
+  if (data.notify.includes("notification")) {
     showBrowserRealtimeNotification(data, settingsStore.settings.notification)
   }
 
-  if (!data.notify) {
+  if (data.notify.length === 0) {
     return
   }
 

--- a/front/src/services/realtime/events.ts
+++ b/front/src/services/realtime/events.ts
@@ -14,6 +14,17 @@ export function showRealtimeMessage(event: RealtimeEvent): void {
   showGlobalMessage(event.level, formatMessageContent(event))
 }
 
+/**
+ * Naive UI Toast 轻提示（display="toast" 时触发）。
+ */
+export function showToastMessage(event: RealtimeEvent): void {
+  if (typeof window === "undefined" || !window.$message) {
+    return
+  }
+  const type = event.level === "error" ? "error" : event.level === "success" ? "success" : "info"
+  window.$message[type](event.message, { duration: 3000 })
+}
+
 export function showBrowserRealtimeNotification(
   event: RealtimeEvent,
   settings: NotificationSettings,

--- a/front/src/services/realtime/events.ts
+++ b/front/src/services/realtime/events.ts
@@ -15,7 +15,7 @@ export function showRealtimeMessage(event: RealtimeEvent): void {
 }
 
 /**
- * Naive UI Toast 轻提示（display="toast" 时触发）。
+ * Naive UI Toast 轻提示（notify 包含 "toast" 时触发）。
  */
 export function showToastMessage(event: RealtimeEvent): void {
   if (typeof window === "undefined" || !window.$message) {
@@ -29,7 +29,7 @@ export function showBrowserRealtimeNotification(
   event: RealtimeEvent,
   settings: NotificationSettings,
 ): void {
-  if (!event.notify || !settings.browserNotification) {
+  if (!settings.browserNotification) {
     return
   }
   if (typeof Notification === "undefined" || Notification.permission !== "granted") {

--- a/front/src/services/realtime/sse.ts
+++ b/front/src/services/realtime/sse.ts
@@ -101,6 +101,10 @@ export class SSEClient {
       time: ("time" in data && typeof data.time === "string" ? data.time : "") || "",
       notify: ("notify" in data && typeof data.notify === "boolean" ? data.notify : false) || false,
       title: "title" in data && typeof data.title === "string" ? data.title : null,
+      details:
+        "details" in data && data.details && typeof data.details === "object"
+          ? (data.details as Record<string, unknown>)
+          : null,
     }
   }
 

--- a/front/src/services/realtime/sse.ts
+++ b/front/src/services/realtime/sse.ts
@@ -2,7 +2,7 @@ import type { RealtimeEvent, RealtimeEventLevel, RealtimeEventName } from "@/typ
 
 type SSEPayload =
   | RealtimeEvent
-  | { type?: string; message?: string; time?: string; notify?: boolean }
+  | { type?: string; message?: string; time?: string; notify?: string[] }
 
 export class SSEClient {
   private eventSource: EventSource | null = null
@@ -99,12 +99,13 @@ export class SSEClient {
       level: (level as RealtimeEventLevel) || "info",
       message: data.message,
       time: ("time" in data && typeof data.time === "string" ? data.time : "") || "",
-      notify: ("notify" in data && typeof data.notify === "boolean" ? data.notify : false) || false,
+      notify: Array.isArray(data.notify) ? data.notify : [],
       title: "title" in data && typeof data.title === "string" ? data.title : null,
       details:
         "details" in data && data.details && typeof data.details === "object"
           ? (data.details as Record<string, unknown>)
           : null,
+      display: "display" in data ? Boolean(data.display) : true,
     }
   }
 

--- a/front/src/types/realtime/model.ts
+++ b/front/src/types/realtime/model.ts
@@ -1,9 +1,16 @@
 export type RealtimeEventName =
   | "log"
+  | "focus.display"
   | "task.started"
   | "task.completed"
   | "task.failed"
   | "notification.test"
+  | "resource.loading"
+  | "controller.action"
+  | "tasker.task"
+  | "node.recognition"
+  | "node.action"
+  | "sink"
 
 export type RealtimeEventLevel = "info" | "success" | "error"
 
@@ -14,4 +21,6 @@ export interface RealtimeEvent {
   time: string
   notify: boolean
   title?: string | null
+  details?: Record<string, unknown> | null
+  display?: string[]
 }

--- a/front/src/types/realtime/model.ts
+++ b/front/src/types/realtime/model.ts
@@ -19,8 +19,8 @@ export interface RealtimeEvent {
   level: RealtimeEventLevel
   message: string
   time: string
-  notify: boolean
+  notify: string[]
   title?: string | null
   details?: Record<string, unknown> | null
-  display?: string[]
+  display: boolean
 }

--- a/maa_utils.py
+++ b/maa_utils.py
@@ -18,6 +18,7 @@ from maa_worker.runtime import (
     TaskRuntimeState,
     WorkerContext,
 )
+from maa_worker.sink_service import SinkHandler, SinkService
 from maa_worker.task_service import TaskService
 from models.interface import InterfaceModel
 
@@ -51,6 +52,10 @@ class MaaWorker:
         self.agents = AgentService(self)
         self.tasks = TaskService(self)
 
+        self._sink_handler = SinkHandler(self)
+        self.sinks = SinkService(self._sink_handler)
+        self.sinks.register_all(self.resource, self.tasker)
+
         self.events.send_log("MAA初始化成功")
 
     def get_screencap_bytes(self):
@@ -71,6 +76,11 @@ class MaaWorker:
         return None
 
     def shutdown(self):
+        self.sinks.unregister_all(
+            self.resource,
+            self.tasker,
+            controller=self.device_state.controller,
+        )
         if self.agent_state.agent_client is not None:
             self.agent_state.agent_client.disconnect()
         for process in self.agent_state.processes:

--- a/maa_worker/agent_loader.py
+++ b/maa_worker/agent_loader.py
@@ -1,3 +1,4 @@
+import ast
 import importlib.abc
 import importlib.machinery
 import importlib.util
@@ -17,6 +18,14 @@ if TYPE_CHECKING:
 
 from maa.resource import Resource
 from maa.agent_client import AgentClient
+
+# Sink 基类名称映射 — 用于 AST 隐式继承检测
+_SINK_BASE_CLASS_MAP: dict[str, str] = {
+    "ResourceEventSink": "resource",
+    "ControllerEventSink": "controller",
+    "TaskerEventSink": "tasker",
+    "ContextEventSink": "context",
+}
 
 
 class _DepsFirstFinder(importlib.abc.MetaPathFinder):
@@ -325,11 +334,14 @@ def _black_magic_agent_server_stub():
             delattr(maa_module, "agent")
 
 
-def run_black_magic(agent_config: Any, resource: Resource):
+def run_black_magic(agent_config: Any, maa_worker: "MaaWorker"):
     """
     将Agent转换为custom的黑魔法
-    动态加载并注册自定义 Action 和 Recognition
+    动态加载并注册自定义 Action、Recognition 以及 EventSink 子类
     """
+    tasker = maa_worker.tasker
+    controller = maa_worker.device_state.controller
+    resource = maa_worker.resource
     runtime_root = _resolve_runtime_root()
     agent_index_path = _resolve_agent_index_path(agent_config, runtime_root)
     deps_path = runtime_root / "deps"
@@ -414,13 +426,14 @@ def run_black_magic(agent_config: Any, resource: Resource):
     custom_recognition_pattern = re.compile(
         r"@AgentServer.custom_recognition\(\".*\"\)"
     )
-    to_register = {"action": [], "recognition": []}
+    to_register = {"action": [], "recognition": [], "sink": []}
 
     for module_name, info in module_map.items():
         file_path = info.get("path")
         try:
             with open(file_path, "r", encoding="utf-8") as f:
-                lines = f.readlines()
+                source = f.read()
+            lines = source.splitlines(True)
 
             for i, line in enumerate(lines):
                 match_action = re.match(custom_action_pattern, line.strip())
@@ -445,6 +458,32 @@ def run_black_magic(agent_config: Any, resource: Resource):
                                     "module_name": module_name,
                                 }
                             )
+
+            # --- AST 隐式继承检测：EventSink 子类 -------------------------------
+            try:
+                tree = ast.parse(source, filename=file_path)
+                for node in ast.walk(tree):
+                    if not isinstance(node, ast.ClassDef):
+                        continue
+                    for base in node.bases:
+                        base_name: str | None = None
+                        if isinstance(base, ast.Name):
+                            base_name = base.id
+                        elif isinstance(base, ast.Attribute):
+                            base_name = base.attr
+                        if base_name is None or base_name not in _SINK_BASE_CLASS_MAP:
+                            continue
+                        sink_type = _SINK_BASE_CLASS_MAP[base_name]
+                        to_register["sink"].append(
+                            {
+                                "class_name": node.name,
+                                "module_name": module_name,
+                                "sink_type": sink_type,
+                            }
+                        )
+                        break  # 只匹配第一个能够识别的基类
+            except SyntaxError:
+                pass  # 非 Python 源文件容忍语法错误
         except Exception as e:
             print(f"Error scanning {file_path}: {e}")
             traceback.print_exc()
@@ -481,6 +520,33 @@ def run_black_magic(agent_config: Any, resource: Resource):
                         )
                         traceback.print_exc()
                         raise
+
+            # --- 注册嵌入式 Sink -------------------------------------------------
+            for item in to_register["sink"]:
+                try:
+                    module = sys.modules.get(item["module_name"])
+                    if module is None:
+                        continue
+                    cls = getattr(module, item["class_name"])
+                    instance = cls()
+                    sink_type = item["sink_type"]
+
+                    if sink_type == "resource":
+                        resource.add_sink(instance)
+                    elif sink_type == "controller":
+                        if controller is not None:
+                            controller.add_sink(instance)
+                    elif sink_type == "tasker":
+                        tasker.add_sink(instance)
+                    elif sink_type == "context":
+                        tasker.add_context_sink(instance)
+                except Exception as e:
+                    print(
+                        f"Warning: Failed to register sink "
+                        f"'{item['class_name']}' ({item['sink_type']}): {e}"
+                    )
+                    traceback.print_exc()
+                    raise
     finally:
         # 确保清理 loader，避免污染全局导入链
         if loader in sys.meta_path:
@@ -503,7 +569,7 @@ def load_agents(
             try:
                 if pi_env:
                     os.environ.update(pi_env)
-                run_black_magic(agent_config, maa_worker.resource)
+                run_black_magic(agent_config, maa_worker)
             except Exception as e:
                 maa_worker.events.send_log("黑魔法爆炸了！")
                 maa_worker.events.send_log(f"自定义Agent加载失败: {e}")

--- a/maa_worker/agent_loader.py
+++ b/maa_worker/agent_loader.py
@@ -482,8 +482,8 @@ def run_black_magic(agent_config: Any, maa_worker: "MaaWorker"):
                             }
                         )
                         break  # 只匹配第一个能够识别的基类
-            except SyntaxError:
-                pass  # 非 Python 源文件容忍语法错误
+            except SyntaxError as e:
+                print(f"Syntax error in {file_path}: {e}")
         except Exception as e:
             print(f"Error scanning {file_path}: {e}")
             traceback.print_exc()

--- a/maa_worker/device_service.py
+++ b/maa_worker/device_service.py
@@ -283,6 +283,11 @@ class DeviceService:
             or state.controller_name is not None
             or state.controller_type is not None
         )
+
+        # 注销 controller sink
+        if state.controller is not None and hasattr(self.worker, "sinks"):
+            self.worker.sinks.unregister_controller_sink(state.controller)
+
         state.connected = False
         state.configuration_locked = False
         state.controller = None
@@ -370,6 +375,11 @@ class DeviceService:
             state.controller_type = device_type
             state.controller_name = selected_controller.name
             state.last_device_error = None
+
+            # 注册 controller sink
+            if hasattr(self.worker, "sinks"):
+                self.worker.sinks.register_controller_sink(controller)
+
             self.worker.events.send_log("设备连接成功")
             return True
 

--- a/maa_worker/event_service.py
+++ b/maa_worker/event_service.py
@@ -55,6 +55,7 @@ class EventService:
         level: RealtimeEventLevel = "info",
         notify: bool = False,
         title: str | None = None,
+        display: list[str] | None = None,
     ):
         realtime_event = RealtimeEvent(
             event=event,
@@ -63,6 +64,7 @@ class EventService:
             time=current_time(),
             notify=notify,
             title=title,
+            display=display or ["log"],
         )
 
         self._publish_event(realtime_event)

--- a/maa_worker/event_service.py
+++ b/maa_worker/event_service.py
@@ -53,10 +53,11 @@ class EventService:
         message: str,
         *,
         level: RealtimeEventLevel = "info",
-        notify: bool = False,
+        notify: list[str] | None = None,
         title: str | None = None,
-        display: list[str] | None = None,
+        display: bool = True,
     ):
+        notify = notify or []
         realtime_event = RealtimeEvent(
             event=event,
             level=level,
@@ -64,12 +65,12 @@ class EventService:
             time=current_time(),
             notify=notify,
             title=title,
-            display=display or ["log"],
+            display=display,
         )
 
         self._publish_event(realtime_event)
 
-        if not notify:
+        if "notification" not in notify:
             return
 
         settings = load_settings()
@@ -154,8 +155,11 @@ class EventService:
         *,
         event: RealtimeEventName = "notification.test",
         level: RealtimeEventLevel = "info",
+        notify: list[str] | None = None,
     ):
-        self.emit(event, message, level=level, notify=True, title=title)
+        self.emit(
+            event, message, level=level, notify=notify or ["notification"], title=title
+        )
 
     def _build_task_subject(self, task_list: list[str]) -> str:
         if self.worker.task_state.current_task_name:
@@ -178,7 +182,7 @@ class EventService:
             "task.completed",
             f"{self._build_task_subject(task_list)} 执行完成",
             level="success",
-            notify=settings.notification.notifyOnComplete,
+            notify=["notification"] if settings.notification.notifyOnComplete else [],
             title="任务完成",
         )
 
@@ -188,7 +192,7 @@ class EventService:
             "task.failed",
             f"{self._build_task_subject(task_list)} 执行失败，请检查日志",
             level="error",
-            notify=settings.notification.notifyOnError,
+            notify=["notification"] if settings.notification.notifyOnError else [],
             title="任务失败",
         )
         self.send_log(f"任务异常详情: {error_message}")

--- a/maa_worker/focus_processor.py
+++ b/maa_worker/focus_processor.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from maa_worker.focus_protocol import (
-    DISPLAY_LOG,
     DISPLAY_NOTIFICATION,
     DISPLAY_TOAST,
     FocusDisplayEvent,
@@ -29,29 +28,16 @@ class FocusEventProcessor:
         self._events = events
 
     def dispatch(self, event: FocusDisplayEvent) -> None:
-        content = event.content
-        level = event.level
-
-        if event.has_log:
-            self._events.emit(
-                "focus.display",
-                content,
-                level=level,
-                display=[DISPLAY_LOG],
-            )
-
+        notify: list[str] = []
         if event.has_toast:
-            self._events.emit(
-                "focus.display",
-                content,
-                level=level,
-                display=[DISPLAY_TOAST],
-            )
-
+            notify.append(DISPLAY_TOAST)
         if event.has_notification:
-            self._events.send_notification(
-                "任务通知",
-                content,
-                event="focus.display",
-                level=level,
-            )
+            notify.append(DISPLAY_NOTIFICATION)
+
+        self._events.emit(
+            "focus.display",
+            event.content,
+            display=event.has_log,
+            notify=notify,
+            level=event.level,
+        )

--- a/maa_worker/focus_processor.py
+++ b/maa_worker/focus_processor.py
@@ -1,0 +1,57 @@
+"""
+Focus 事件处理器 — 按 display_channels 将 FocusDisplayEvent 分发到对应通道。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from maa_worker.focus_protocol import (
+    DISPLAY_LOG,
+    DISPLAY_NOTIFICATION,
+    DISPLAY_TOAST,
+    FocusDisplayEvent,
+)
+
+if TYPE_CHECKING:
+    from maa_worker.event_service import EventService
+
+
+class FocusEventProcessor:
+    """将 FocusDisplayEvent 按 display_channels 分发。
+
+    - "log":          SSE 日志推送
+    - "toast":        SSE toast 推送（前端 Naive UI 渲染）
+    - "notification": 系统通知 (plyer / browser Notification)
+    """
+
+    def __init__(self, events: "EventService") -> None:
+        self._events = events
+
+    def dispatch(self, event: FocusDisplayEvent) -> None:
+        content = event.content
+        level = event.level
+
+        if event.has_log:
+            self._events.emit(
+                "focus.display",
+                content,
+                level=level,
+                display=[DISPLAY_LOG],
+            )
+
+        if event.has_toast:
+            self._events.emit(
+                "focus.display",
+                content,
+                level=level,
+                display=[DISPLAY_TOAST],
+            )
+
+        if event.has_notification:
+            self._events.send_notification(
+                "任务通知",
+                content,
+                event="focus.display",
+                level=level,
+            )

--- a/maa_worker/focus_protocol.py
+++ b/maa_worker/focus_protocol.py
@@ -19,7 +19,6 @@ DISPLAY_NOTIFICATION = "notification"
 # "dialog" / "modal" reserved for future PR
 
 _VALID_DISPLAYS = frozenset({DISPLAY_LOG, DISPLAY_TOAST, DISPLAY_NOTIFICATION})
-_DEFAULT_DISPLAY = [DISPLAY_LOG]
 
 # ---------------------------------------------------------------------------
 # FocusTemplate — 表示 interface.json 中一条 focus 模板

--- a/maa_worker/focus_protocol.py
+++ b/maa_worker/focus_protocol.py
@@ -1,0 +1,275 @@
+"""
+Focus 协议实现 — 严格遵循 PI V2 v2.3.0 官方规范。
+
+将 MAA 底层 sink 回调统一解析为 FocusDisplayEvent，
+按 `display` 字段指定的渠道（log / toast / notification）分发。
+"""
+
+from dataclasses import dataclass, field
+
+from models.api import RealtimeEventLevel
+
+# ---------------------------------------------------------------------------
+# Supported display channels (PI V2 v2.3.0)
+# ---------------------------------------------------------------------------
+
+DISPLAY_LOG = "log"
+DISPLAY_TOAST = "toast"
+DISPLAY_NOTIFICATION = "notification"
+# "dialog" / "modal" reserved for future PR
+
+_VALID_DISPLAYS = frozenset({DISPLAY_LOG, DISPLAY_TOAST, DISPLAY_NOTIFICATION})
+_DEFAULT_DISPLAY = [DISPLAY_LOG]
+
+# ---------------------------------------------------------------------------
+# FocusTemplate — 表示 interface.json 中一条 focus 模板
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FocusTemplate:
+    """Focus 模板（仅 v2.3.0 对象格式）。
+
+    简写纯字符串在 from_raw() 中自动升级：
+        "text" → FocusTemplate(content="text", display=["log"])
+    """
+
+    content: str
+    display: list[str] = field(default_factory=lambda: [DISPLAY_LOG])
+
+    # ---- 工厂方法 ------------------------------------------------------------
+
+    @staticmethod
+    def from_raw(raw: object) -> "FocusTemplate":
+        """从 interface.json 的 focus 值构造模板。
+
+        支持：
+        - str : 简写，等价 display=["log"]
+        - dict: 完整对象 { "content": "...", "display": [...] }
+        """
+        if isinstance(raw, str):
+            return FocusTemplate(content=raw, display=[DISPLAY_LOG])
+
+        if isinstance(raw, dict):
+            content = raw.get("content", "")
+            if not isinstance(content, str):
+                content = str(content)
+
+            raw_display = raw.get("display", DISPLAY_LOG)
+            if isinstance(raw_display, str):
+                display = (
+                    [raw_display] if raw_display in _VALID_DISPLAYS else [DISPLAY_LOG]
+                )
+            elif isinstance(raw_display, (list, tuple)):
+                display = [
+                    d
+                    for d in raw_display
+                    if isinstance(d, str) and d in _VALID_DISPLAYS
+                ]
+                if not display:
+                    display = [DISPLAY_LOG]
+            else:
+                display = [DISPLAY_LOG]
+            return FocusTemplate(content=content, display=display)
+
+        # 兜底：无法识别的类型
+        return FocusTemplate(content=str(raw), display=[DISPLAY_LOG])
+
+
+# ---------------------------------------------------------------------------
+# AutoFocusGenerator — 无 focus 定义时生成默认日志文本
+# ---------------------------------------------------------------------------
+
+# 复用原 _PREFIX_MAP 的类别标签
+_CATEGORY_LABEL: dict[str, str] = {
+    "Resource.Loading": "资源",
+    "Controller.Action": "控制器",
+    "Tasker.Task": "任务",
+    "Node.Recognition": "识别",
+    "Node.Action": "动作",
+    "Node.WaitFreezes": "等待",
+    "Node.NextList": "下一节点",
+    "Node.PipelineNode": "流水线",
+    "Node.RecognitionNode": "识别节点",
+    "Node.ActionNode": "动作节点",
+}
+
+_STATUS_CN: dict[str, str] = {
+    "Starting": "开始",
+    "Succeeded": "成功",
+    "Failed": "失败",
+}
+
+
+class AutoFocusGenerator:
+    """当 details.focus 无对应条目时，根据消息类型自动生成人类可读的默认文本。"""
+
+    @staticmethod
+    def generate(msg: str, details: dict) -> str:
+        status_suffix = msg.rsplit(".", 1)[-1] if "." in msg else msg
+        status_cn = _STATUS_CN.get(status_suffix, status_suffix)
+
+        # 查找类别标签
+        category = "回调"
+        for prefix, label in _CATEGORY_LABEL.items():
+            if msg.startswith(prefix):
+                category = label
+                break
+
+        name = details.get("name", "")
+        entry = details.get("entry", "")
+        path = details.get("path", "")
+        res_type = details.get("type", "")
+        uuid = details.get("uuid", "")
+        hash_val = details.get("hash", "")
+
+        parts: list[str] = []
+
+        if msg.startswith("Tasker.Task"):
+            if entry:
+                parts.append(f"任务 [{entry}]")
+            if uuid:
+                parts.append(f"ID={str(uuid)[:8]}")
+            parts.append(status_cn)
+
+        elif msg.startswith("Node."):
+            parts.append(name if name else category)
+            parts.append(status_cn)
+
+        elif msg.startswith("Resource."):
+            if path:
+                parts.append(f"路径={path}")
+            if res_type:
+                parts.append(f"类型={res_type}")
+            if hash_val:
+                parts.append(f"hash={str(hash_val)[:8]}")
+            parts.append(status_cn)
+
+        elif msg.startswith("Controller."):
+            parts.append(status_cn)
+
+        else:
+            parts.append(msg)
+
+        return " ".join(parts) if parts else msg
+
+
+# ---------------------------------------------------------------------------
+# FocusDisplayEvent — 统一事件输出模型
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FocusDisplayEvent:
+    """所有 sink 回调最终产出的统一事件。
+
+    对应官方协议 Client 处理流程第 6 步：
+    「根据 display 指定的渠道将文本展示给用户」。
+    """
+
+    content: str
+    display_channels: list[str]
+    level: RealtimeEventLevel = "info"
+    raw_msg: str = ""
+
+    @property
+    def has_log(self) -> bool:
+        return DISPLAY_LOG in self.display_channels
+
+    @property
+    def has_toast(self) -> bool:
+        return DISPLAY_TOAST in self.display_channels
+
+    @property
+    def has_notification(self) -> bool:
+        return DISPLAY_NOTIFICATION in self.display_channels
+
+
+# ---------------------------------------------------------------------------
+# UnifiedFocusResolver — 统一解析入口
+# ---------------------------------------------------------------------------
+
+
+class UnifiedFocusResolver:
+    """将 MAA 原始 (msg, details) 统一解析为 FocusDisplayEvent。
+
+    严格遵循 PI V2 v2.3.0 Client 处理流程：
+    1. 从 details.focus[msg] 查找模板
+    2. 简写字符串自动升级为 {content, display:["log"]}
+    3. 无匹配时使用 AutoFocusGenerator
+    4. 占位符替换 {name}/{task_id}/{entry}/...
+    5. 推导 level
+    6. 返回 FocusDisplayEvent
+    """
+
+    @staticmethod
+    def resolve(msg: str, details: dict) -> FocusDisplayEvent:
+        template = UnifiedFocusResolver._find_template(msg, details)
+        content = UnifiedFocusResolver._substitute(template.content, details)
+        level = UnifiedFocusResolver._derive_level(msg)
+        channels = _sanitize_display(template.display)
+
+        return FocusDisplayEvent(
+            content=content,
+            display_channels=channels,
+            level=level,
+            raw_msg=msg,
+        )
+
+    # ---- 内部方法 ------------------------------------------------------------
+
+    @staticmethod
+    def _find_template(msg: str, details: dict) -> FocusTemplate:
+        """从 details.focus 中查找匹配的模板。"""
+        focus = details.get("focus")
+        if isinstance(focus, dict):
+            # 1) 精确匹配 msg（如 "Node.Action.Starting"）
+            raw = focus.get(msg)
+            if raw is not None:
+                return FocusTemplate.from_raw(raw)
+
+            # 2) 尝试用 name 作为 fallback key
+            name = details.get("name", "")
+            if name and name in focus:
+                raw = focus.get(name)
+                if raw is not None:
+                    return FocusTemplate.from_raw(raw)
+
+            # 3) 尝试用状态后缀作为 fallback key
+            suffix = msg.rsplit(".", 1)[-1] if "." in msg else ""
+            if suffix and suffix in focus:
+                raw = focus.get(suffix)
+                if raw is not None:
+                    return FocusTemplate.from_raw(raw)
+
+        # 无 focus 定义 → 自动生成默认模板
+        return FocusTemplate(
+            content=AutoFocusGenerator.generate(msg, details),
+            display=[DISPLAY_LOG],
+        )
+
+    @staticmethod
+    def _substitute(content: str, details: dict) -> str:
+        """替换占位符：{name}, {task_id}, {entry}, {list}。"""
+        if "{" not in content:
+            return content
+
+        content = content.replace("{name}", str(details.get("name", "")))
+        content = content.replace("{task_id}", str(details.get("task_id", "")))
+        content = content.replace("{entry}", str(details.get("entry", "")))
+        content = content.replace("{list}", str(details.get("list", "")))
+        return content
+
+    @staticmethod
+    def _derive_level(msg: str) -> RealtimeEventLevel:
+        if msg.endswith(".Succeeded"):
+            return "success"
+        if msg.endswith(".Failed"):
+            return "error"
+        return "info"
+
+
+def _sanitize_display(raw: list[str]) -> list[str]:
+    """过滤只保留支持的 display 通道，确保至少有一个。"""
+    valid = [d for d in raw if d in _VALID_DISPLAYS]
+    return valid if valid else [DISPLAY_LOG]

--- a/maa_worker/sink_service.py
+++ b/maa_worker/sink_service.py
@@ -1,0 +1,165 @@
+"""
+MAA Sink 回调协议集成 — 统一 Focus 协议管线。
+
+所有 MAA 底层事件回调通过 UnifiedFocusResolver 解析为
+FocusDisplayEvent，再由 FocusEventProcessor 按 display 通道
+分发到 SSE / 系统通知。
+"""
+
+from typing import TYPE_CHECKING
+
+from maa.event_sink import EventSink
+
+from maa_worker.focus_processor import FocusEventProcessor
+from maa_worker.focus_protocol import UnifiedFocusResolver
+
+if TYPE_CHECKING:
+    from maa_utils import MaaWorker
+
+
+# ---------------------------------------------------------------------------
+# Sink 实例类 — 继承 EventSink，转发到共享 handler
+# ---------------------------------------------------------------------------
+
+
+class _SinkBase(EventSink):
+    """所有 MWU sink 的公共基类 — 持有 handler 引用并在回调时转发。"""
+
+    def __init__(self, handler: "SinkHandler"):
+        super().__init__()
+        self._handler = handler
+
+    def _on_raw_notification(self, handle, msg: str, details: dict):
+        self._handler.on_event(msg, details)
+
+
+class MWUResourceSink(_SinkBase):
+    """资源加载事件的 sink。"""
+
+
+class MWUControllerSink(_SinkBase):
+    """控制器动作事件的 sink。"""
+
+
+class MWUTaskerSink(_SinkBase):
+    """任务器事件的 sink。"""
+
+
+class MWUContextSink(_SinkBase):
+    """任务上下文（节点）事件的 sink。"""
+
+
+# ---------------------------------------------------------------------------
+# SinkHandler — 核心分发器（统一 Focus 协议管线）
+# ---------------------------------------------------------------------------
+
+
+class SinkHandler:
+    """将 MAA 底层回调通过 UnifiedFocusResolver → FocusEventProcessor 统一处理。"""
+
+    def __init__(self, worker: "MaaWorker"):
+        self.worker = worker
+        self._resolver = UnifiedFocusResolver()
+        self._processor = FocusEventProcessor(worker.events)
+
+    def on_event(self, msg: str, details: dict) -> None:
+        """统一的 sink 事件入口。
+
+        完全遵循 PI V2 v2.3.0 Client 处理流程：
+        1. UnifiedFocusResolver 解析 (msg, details) → FocusDisplayEvent
+        2. FocusEventProcessor 按 display_channels 分发到 SSE / 系统通知
+        """
+        event = self._resolver.resolve(msg, details)
+        self._processor.dispatch(event)
+
+
+# ---------------------------------------------------------------------------
+# SinkService — 管理 sink 注册 / 注销生命周期
+# ---------------------------------------------------------------------------
+
+
+class SinkService:
+    """统一管理 Resource / Controller / Tasker / Context 四类 sink 的注册和清理。"""
+
+    def __init__(self, handler: SinkHandler):
+        self._handler = handler
+        self._resource_sink = MWUResourceSink(handler)
+        self._controller_sink = MWUControllerSink(handler)
+        self._tasker_sink = MWUTaskerSink(handler)
+        self._context_sink = MWUContextSink(handler)
+
+        # 已注册的 sink_id
+        self._resource_sink_id: int | None = None
+        self._controller_sink_id: int | None = None
+        self._tasker_sink_id: int | None = None
+        self._context_sink_id: int | None = None
+
+    # ---- Resource ----------------------------------------------------------
+
+    def register_resource_sink(self, resource) -> int | None:
+        if self._resource_sink_id is not None:
+            return self._resource_sink_id
+        sid = resource.add_sink(self._resource_sink)
+        self._resource_sink_id = sid
+        return sid
+
+    def unregister_resource_sink(self, resource) -> None:
+        if self._resource_sink_id is not None:
+            resource.remove_sink(self._resource_sink_id)
+            self._resource_sink_id = None
+
+    # ---- Controller --------------------------------------------------------
+
+    def register_controller_sink(self, controller) -> int | None:
+        if self._controller_sink_id is not None:
+            return self._controller_sink_id
+        sid = controller.add_sink(self._controller_sink)
+        self._controller_sink_id = sid
+        return sid
+
+    def unregister_controller_sink(self, controller) -> None:
+        if self._controller_sink_id is not None:
+            controller.remove_sink(self._controller_sink_id)
+            self._controller_sink_id = None
+
+    # ---- Tasker ------------------------------------------------------------
+
+    def register_tasker_sink(self, tasker) -> int | None:
+        if self._tasker_sink_id is not None:
+            return self._tasker_sink_id
+        sid = tasker.add_sink(self._tasker_sink)
+        self._tasker_sink_id = sid
+        return sid
+
+    def unregister_tasker_sink(self, tasker) -> None:
+        if self._tasker_sink_id is not None:
+            tasker.remove_sink(self._tasker_sink_id)
+            self._tasker_sink_id = None
+
+    # ---- Context -----------------------------------------------------------
+
+    def register_context_sink(self, tasker) -> int | None:
+        if self._context_sink_id is not None:
+            return self._context_sink_id
+        sid = tasker.add_context_sink(self._context_sink)
+        self._context_sink_id = sid
+        return sid
+
+    def unregister_context_sink(self, tasker) -> None:
+        if self._context_sink_id is not None:
+            tasker.remove_context_sink(self._context_sink_id)
+            self._context_sink_id = None
+
+    # ---- Batch -------------------------------------------------------------
+
+    def register_all(self, resource, tasker) -> None:
+        self.register_resource_sink(resource)
+        self.register_tasker_sink(tasker)
+        self.register_context_sink(tasker)
+
+    def unregister_all(self, resource, tasker, controller=None) -> None:
+        self.unregister_resource_sink(resource)
+        self.unregister_tasker_sink(tasker)
+        self.unregister_context_sink(tasker)
+        if controller is not None:
+            self.unregister_controller_sink(controller)

--- a/models/api.py
+++ b/models/api.py
@@ -1,13 +1,19 @@
-from typing import Literal
-
+from typing import Any, Literal
 from pydantic import BaseModel
 
 RealtimeEventName = Literal[
     "log",
+    "focus.display",
     "task.started",
     "task.completed",
     "task.failed",
     "notification.test",
+    "resource.loading",
+    "controller.action",
+    "tasker.task",
+    "node.recognition",
+    "node.action",
+    "sink",
 ]
 RealtimeEventLevel = Literal["info", "success", "error"]
 
@@ -33,3 +39,5 @@ class RealtimeEvent(BaseModel):
     time: str
     notify: bool = False
     title: str | None = None
+    details: dict[str, Any] | None = None
+    display: list[str] = ["log"]

--- a/models/api.py
+++ b/models/api.py
@@ -1,5 +1,5 @@
 from typing import Any, Literal
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 RealtimeEventName = Literal[
     "log",
@@ -37,7 +37,7 @@ class RealtimeEvent(BaseModel):
     level: RealtimeEventLevel = "info"
     message: str
     time: str
-    notify: bool = False
+    notify: list[str] = Field(default_factory=list)
     title: str | None = None
     details: dict[str, Any] | None = None
-    display: list[str] = ["log"]
+    display: bool = True


### PR DESCRIPTION
This pull request introduces significant enhancements to the real-time event system, focusing on extensibility and flexibility in event handling and display. The backend now supports registering and dispatching custom "sink" event handlers (EventSink subclasses) for different components, and the frontend can handle new event types and display channels (log, toast, notification). These changes enable more granular control over how events are processed and shown to users, and make it easier to extend the system with custom behaviors.

**Backend: Event Sink Registration & Focus Event Processing**

- **Dynamic EventSink Registration for Agents:**  
  The agent loader now detects and registers custom EventSink subclasses (for resource, controller, tasker, context) via AST parsing, allowing agent authors to extend event handling by simply subclassing the appropriate base class. Registration and unregistration are handled for the relevant components, including during device connect/disconnect. [[1]](diffhunk://#diff-2ae7d0321c8a5eb19031410d6e0306e059ddc8e63ed664668a53e1dff92921e4R22-R29) F0a3e77fL414R458, [[2]](diffhunk://#diff-2ae7d0321c8a5eb19031410d6e0306e059ddc8e63ed664668a53e1dff92921e4R523-R549) [[3]](diffhunk://#diff-2ae7d0321c8a5eb19031410d6e0306e059ddc8e63ed664668a53e1dff92921e4L506-R572) [[4]](diffhunk://#diff-d10561fa226e48fb64aca88029e8ac77e243200ff4689612760a8f879e3dbe45R21) [[5]](diffhunk://#diff-d10561fa226e48fb64aca88029e8ac77e243200ff4689612760a8f879e3dbe45R55-R58) [[6]](diffhunk://#diff-d10561fa226e48fb64aca88029e8ac77e243200ff4689612760a8f879e3dbe45R79-R83) [[7]](diffhunk://#diff-16715fd92c99a082abaf060734601da64c166ca43cc7f67f9955c74bf85fc811R286-R290) [[8]](diffhunk://#diff-16715fd92c99a082abaf060734601da64c166ca43cc7f67f9955c74bf85fc811R378-R382)

- **Focus Event Processing:**  
  Added a new `FocusEventProcessor` that dispatches `FocusDisplayEvent` to different display channels ("log", "toast", "notification") by emitting appropriate real-time events, supporting more flexible UI feedback.

- **Realtime Event Model Enhancements:**  
  The `RealtimeEvent` model now supports an optional `details` field for structured data and a `display` field to specify intended display channels. [[1]](diffhunk://#diff-2da2b9ee0351878bbde04fbf87a7992c665055da33c4d35aceb62555909c0b88R24-R25) [[2]](diffhunk://#diff-844a3b445e201d9136f618633d55ec0cb64e3046fb6a74113bbd14092a9c5fb2R58) [[3]](diffhunk://#diff-844a3b445e201d9136f618633d55ec0cb64e3046fb6a74113bbd14092a9c5fb2R67)

- **Efficient Log History Storage:**  
  Switched `history_message` from a list to a bounded `deque` (maxlen 2000) to prevent unbounded memory growth for log history. [[1]](diffhunk://#diff-3abeb67ce8fe35666e5c2bd99753de28ac52ce27aecf237a53832f790fec5e0eR4) [[2]](diffhunk://#diff-3abeb67ce8fe35666e5c2bd99753de28ac52ce27aecf237a53832f790fec5e0eR14-R21) [[3]](diffhunk://#diff-3abeb67ce8fe35666e5c2bd99753de28ac52ce27aecf237a53832f790fec5e0eL62-R66)

**Frontend: Event Handling and Display**

- **Support for New Event Types and Display Channels:**  
  The frontend now recognizes additional event types (e.g., "focus.display", "resource.loading", "controller.action", etc.) and respects the `display` field to determine how to present events (log, toast, notification). [[1]](diffhunk://#diff-2da2b9ee0351878bbde04fbf87a7992c665055da33c4d35aceb62555909c0b88R3-R13) [[2]](diffhunk://#diff-7b58f7323c28e8d4f4a499e94e3c23e984f528aaff2567459bfab796536ff780R28-R65)

- **Toast Message Support:**  
  Added a `showToastMessage` function to display real-time events as Naive UI toasts when `display` includes "toast". [[1]](diffhunk://#diff-7b58f7323c28e8d4f4a499e94e3c23e984f528aaff2567459bfab796536ff780R13) [[2]](diffhunk://#diff-16116046ce6c5a710244ea825adba981ce2407caae4af3c2cc50af7946336ea5R17-R27)

- **Frontend Model and Parsing Updates:**  
  Updated the event model and SSE client parsing logic to handle the new fields (`details`, `display`). [[1]](diffhunk://#diff-2da2b9ee0351878bbde04fbf87a7992c665055da33c4d35aceb62555909c0b88R24-R25) [[2]](diffhunk://#diff-7ffbb9a078c984f9b9de06539b5ce7fb53bb34297bc2f87582e9d4fa8ed34e3eR104-R107)

These improvements provide a more modular, extensible, and user-friendly real-time event system across both backend and frontend.

## Summary by Sourcery

引入统一的 sink/focus 协议管线，将底层 MAA sink 回调转换为结构化的实时事件，并在后端和前端之间提供可配置的展示通道。

新功能：
- 在加载 agents 时，支持自动发现和注册自定义的 `EventSink` 子类，覆盖资源（resources）、控制器（controllers）、任务器（taskers）和上下文（contexts）。
- 添加 Focus 协议实现，将 sink 回调解析为 `FocusDisplayEvents`，并通过 `FocusEventProcessor` 将其路由到日志、toast 和通知等通道。
- 为实时事件扩展更丰富的元数据（带类型的通知列表、details 负载、display 标记），并新增事件类型，例如 `focus.display`、资源/控制器/任务器/节点活动以及通用 sink 事件。
- 使前端能够处理新的实时事件模式，包括基于 display 的选择性日志记录，以及通过 Naive UI 渲染 toast 消息。

增强：
- 在 worker 生命周期内初始化和管理共享的 sink 服务，包括在启动时注册 sinks，在关闭和控制器重新连接时注销 sinks。
- 优化 SSE 客户端解析和浏览器通知逻辑，使其适配基于列表的通知语义以及可选的 `details`/`display` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a unified sink/focus protocol pipeline to turn low-level MAA sink callbacks into structured realtime events with configurable display channels across backend and frontend.

New Features:
- Support automatic discovery and registration of custom EventSink subclasses for resources, controllers, taskers, and contexts when loading agents.
- Add a Focus protocol implementation that resolves sink callbacks into FocusDisplayEvents and routes them through a FocusEventProcessor to log, toast, and notification channels.
- Extend realtime events with richer metadata (typed notify list, details payload, display flag) and new event types such as focus.display, resource/controller/tasker/node activity, and generic sink events.
- Enable frontend handling of the new realtime event schema, including selective logging based on display and rendering toast messages via Naive UI.

Enhancements:
- Initialize and manage shared sink services on the worker lifecycle, including registering sinks on startup and unregistering them on shutdown and controller reconnects.
- Refine SSE client parsing and browser notification logic to work with list-based notify semantics and optional details/display fields.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入统一的 sink/focus 协议管线，将底层 MAA sink 回调转换为结构化的实时事件，并在后端和前端之间提供可配置的展示通道。

新功能：
- 在加载 agents 时，支持自动发现和注册自定义的 `EventSink` 子类，覆盖资源（resources）、控制器（controllers）、任务器（taskers）和上下文（contexts）。
- 添加 Focus 协议实现，将 sink 回调解析为 `FocusDisplayEvents`，并通过 `FocusEventProcessor` 将其路由到日志、toast 和通知等通道。
- 为实时事件扩展更丰富的元数据（带类型的通知列表、details 负载、display 标记），并新增事件类型，例如 `focus.display`、资源/控制器/任务器/节点活动以及通用 sink 事件。
- 使前端能够处理新的实时事件模式，包括基于 display 的选择性日志记录，以及通过 Naive UI 渲染 toast 消息。

增强：
- 在 worker 生命周期内初始化和管理共享的 sink 服务，包括在启动时注册 sinks，在关闭和控制器重新连接时注销 sinks。
- 优化 SSE 客户端解析和浏览器通知逻辑，使其适配基于列表的通知语义以及可选的 `details`/`display` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a unified sink/focus protocol pipeline to turn low-level MAA sink callbacks into structured realtime events with configurable display channels across backend and frontend.

New Features:
- Support automatic discovery and registration of custom EventSink subclasses for resources, controllers, taskers, and contexts when loading agents.
- Add a Focus protocol implementation that resolves sink callbacks into FocusDisplayEvents and routes them through a FocusEventProcessor to log, toast, and notification channels.
- Extend realtime events with richer metadata (typed notify list, details payload, display flag) and new event types such as focus.display, resource/controller/tasker/node activity, and generic sink events.
- Enable frontend handling of the new realtime event schema, including selective logging based on display and rendering toast messages via Naive UI.

Enhancements:
- Initialize and manage shared sink services on the worker lifecycle, including registering sinks on startup and unregistering them on shutdown and controller reconnects.
- Refine SSE client parsing and browser notification logic to work with list-based notify semantics and optional details/display fields.

</details>

</details>