### PR TITLE
refactor: 重构设备和资源选择器，优化定时任务逻辑

### DIFF
--- a/front/src/app/i18n/messages/en-US.json
+++ b/front/src/app/i18n/messages/en-US.json
@@ -142,7 +142,11 @@
           "taskSettings": "Task Settings",
           "preTasks": "Pre-Task"
         },
-        "noOptions": "Nothing here"
+        "noOptions": "Nothing here",
+        "deviceAndResource": "Device & Resource",
+        "controller": "Controller",
+        "deviceAddress": "Device Address",
+        "resource": "Resource"
       },
       "rules": {
         "nameRequired": "Please enter task name",
@@ -207,11 +211,14 @@
     "selectResource": "Please select a resource",
     "connect": "Connect",
     "confirm": "Confirm",
+    "refresh": "Refresh",
     "taskList": "Task List",
     "start": "Start Task",
     "stop": "Stop Task",
     "resetConfig": "Reset Config",
     "noDevice": "No available device",
+    "recentDevices": "Recent",
+    "discoveredDevices": "Discovered",
     "selectTask": "Please select at least one task",
     "noCompatibleTask": "No executable tasks for current resource/controller",
     "resetConfigConfirm": "Are you sure you want to reset all task configurations? This cannot be undone.",

--- a/front/src/app/i18n/messages/zh-CN.json
+++ b/front/src/app/i18n/messages/zh-CN.json
@@ -142,7 +142,11 @@
           "taskSettings": "任务设置",
           "preTasks": "前置任务"
         },
-        "noOptions": "空空如也"
+        "noOptions": "空空如也",
+        "deviceAndResource": "设备与资源",
+        "controller": "控制器",
+        "deviceAddress": "设备地址",
+        "resource": "资源"
       },
       "rules": {
         "nameRequired": "请输入任务名称",
@@ -207,11 +211,14 @@
     "selectResource": "请选择一个资源",
     "connect": "连接",
     "confirm": "确定",
+    "refresh": "刷新",
     "taskList": "任务列表",
     "start": "开始任务",
     "stop": "中止任务",
     "resetConfig": "重置配置",
     "noDevice": "无可用设备",
+    "recentDevices": "最近使用",
+    "discoveredDevices": "已发现设备",
     "selectTask": "请至少选择一个任务",
     "noCompatibleTask": "当前资源/控制器下没有可执行任务",
     "resetConfigConfirm": "确定要重置所有任务配置吗？此操作不可撤销。",

--- a/front/src/components/panel/PanelConnectionTabs.vue
+++ b/front/src/components/panel/PanelConnectionTabs.vue
@@ -65,13 +65,14 @@
 
 <script setup lang="ts">
 import { useI18n } from "vue-i18n"
+import type { SelectOption, SelectGroupOption } from "naive-ui"
 
 const props = defineProps<{
   selectedController: string | null
   selectedDeviceKey: string | null
   playCoverAddress: string
   controllerOptions: Array<{ label: string; value: string; disabled?: boolean }>
-  deviceOptions: Array<{ label: string; value: string; disabled?: boolean }>
+  deviceOptions: Array<SelectOption | SelectGroupOption>
   loading: boolean
   deviceDisabled: boolean
   resourceDisabled: boolean

--- a/front/src/components/panel/PanelConnectionTabs.vue
+++ b/front/src/components/panel/PanelConnectionTabs.vue
@@ -27,18 +27,20 @@
             :options="deviceOptions"
             :loading="loading"
             :disabled="!selectedController || selectedControllerDisabled || deviceDisabled"
+            filterable
+            tag
+            clearable
             class="min-w-[10rem] flex-1"
             @update:value="(value: string | null) => emit('update:selectedDeviceKey', value)"
-            @click="emit('refresh-devices')"
           />
           <n-button
             strong
             secondary
             type="info"
-            :disabled="deviceDisabled"
-            @click="emit('connect-devices')"
+            :disabled="!selectedController || selectedControllerDisabled || deviceDisabled"
+            @click="emit('refresh-devices')"
           >
-            {{ t("panel.connect") }}
+            {{ t("panel.refresh") }}
           </n-button>
         </n-flex>
       </n-tab-pane>
@@ -50,21 +52,11 @@
             :placeholder="t('panel.selectResource')"
             :options="resourcesList"
             :loading="loading"
-            remote
             :disabled="resourceDisabled"
+            clearable
             class="min-w-[12rem] flex-1"
             @update:value="(value: string | null) => emit('update:resource', value)"
-            @click="emit('fetch-resources')"
           />
-          <n-button
-            strong
-            secondary
-            type="info"
-            :disabled="resourceDisabled"
-            @click="emit('confirm-resource')"
-          >
-            {{ t("panel.confirm") }}
-          </n-button>
         </n-flex>
       </n-tab-pane>
     </n-tabs>
@@ -96,9 +88,6 @@ const emit = defineEmits<{
   (e: "update:resource", value: string | null): void
   (e: "controller-change"): void
   (e: "refresh-devices"): void
-  (e: "connect-devices"): void
-  (e: "fetch-resources"): void
-  (e: "confirm-resource"): void
 }>()
 
 const { t } = useI18n()

--- a/front/src/components/panel/PanelControlColumn.vue
+++ b/front/src/components/panel/PanelControlColumn.vue
@@ -4,7 +4,7 @@
     :selected-device-key="selectedDeviceKey"
     :play-cover-address="playCoverAddress"
     :controller-options="controllerOptions"
-    :device-options="deviceOptions as any"
+    :device-options="deviceOptions"
     :loading="loading"
     :device-disabled="isDeviceResourceLocked"
     :resource-disabled="!selectedController || isDeviceResourceLocked"
@@ -18,8 +18,6 @@
     @update:resource="resource = $event"
     @controller-change="handleControllerChange"
     @refresh-devices="refreshDevices"
-    @connect-devices="connectDevices"
-    @confirm-resource="postResourceSelection"
   />
 
   <PresetSelectionCard />

--- a/front/src/components/panel/PanelControlColumn.vue
+++ b/front/src/components/panel/PanelControlColumn.vue
@@ -4,10 +4,10 @@
     :selected-device-key="selectedDeviceKey"
     :play-cover-address="playCoverAddress"
     :controller-options="controllerOptions"
-    :device-options="deviceOptions"
+    :device-options="deviceOptions as any"
     :loading="loading"
     :device-disabled="isDeviceResourceLocked"
-    :resource-disabled="!isCurrentSelectionConnected || isDeviceResourceLocked"
+    :resource-disabled="!selectedController || isDeviceResourceLocked"
     :selected-controller-disabled="selectedControllerDisabled"
     :is-play-cover="selectedControllerCapability?.type === 'PlayCover'"
     :resource="resource"
@@ -19,7 +19,6 @@
     @controller-change="handleControllerChange"
     @refresh-devices="refreshDevices"
     @connect-devices="connectDevices"
-    @fetch-resources="getResourceList"
     @confirm-resource="postResourceSelection"
   />
 
@@ -43,7 +42,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from "vue"
-import { useDialog, useMessage } from "naive-ui"
+import { useDialog, useMessage, type SelectGroupOption, type SelectOption } from "naive-ui"
 import { useI18n } from "vue-i18n"
 import PanelConnectionTabs from "@/components/panel/PanelConnectionTabs.vue"
 import PresetSelectionCard from "@/components/panel/preset/PresetSelectionCard.vue"
@@ -58,7 +57,11 @@ import {
   stopTask,
   type ConnectableDevice,
   type DeviceControllerCapability,
+  type DeviceControllerType,
+  type PostDeviceResult,
+  type PostResourceResult,
 } from "@/services/api"
+import { showGlobalMessage } from "@/services/feedback/message"
 import { useIndexStore, useInterfaceStore, useSettingsStore, useTaskConfigStore } from "@/stores"
 import type { TaskListItem } from "@/types/task-config/model"
 import type { PanelLastConnectedDevice } from "@/types/settings/model"
@@ -97,6 +100,8 @@ const resource = ref<string | null>(null)
 const resourcesList = ref<Array<{ label: string; value: string }>>([])
 const loading = ref(false)
 const isDeviceResourceLocked = ref(false)
+const connectedControllerName = ref<string | null>(null)
+const connectedResourceName = ref<string | null>(null)
 let deviceStatePollTimer: number | null = null
 
 const selectedTaskIds = computed(() =>
@@ -127,25 +132,164 @@ const selectedControllerDisabled = computed(() =>
 
 const selectedControllerName = computed(() => selectedControllerCapability.value?.name || null)
 
-const deviceOptions = computed(() => {
-  if (availableDevices.value.length === 0) {
-    return [{ label: t("panel.noDevice"), value: "none-device", disabled: true }]
+function buildStoredDeviceLabel(stored: PanelLastConnectedDevice): string {
+  if (stored.type === "Adb") {
+    return `${stored.address} (${stored.adb_path})`
   }
-  return availableDevices.value.map((item) => ({
+  if (stored.type === "Win32" || stored.type === "Gamepad") {
+    return `${stored.window_name || stored.class_name} (${stored.class_name || stored.address})`
+  }
+  return stored.address
+}
+
+function buildConnectableDeviceFromStored(stored: PanelLastConnectedDevice): ConnectableDevice {
+  if (stored.type === "Adb") {
+    return {
+      type: "Adb",
+      name: stored.controller_name || stored.address,
+      adb_path: stored.adb_path,
+      address: stored.address,
+      screencap_methods: "",
+      input_methods: "",
+      config: {},
+    }
+  }
+  if (stored.type === "Win32") {
+    return {
+      type: "Win32",
+      hWnd: stored.hWnd,
+      class_name: stored.class_name,
+      window_name: stored.window_name,
+      screencap_methods: 0,
+      input_methods: 0,
+    }
+  }
+  if (stored.type === "Gamepad") {
+    return {
+      type: "Gamepad",
+      hWnd: stored.hWnd,
+      class_name: stored.class_name,
+      window_name: stored.window_name,
+      screencap_methods: 0,
+      gamepad_type: stored.gamepad_type,
+    }
+  }
+  return {
+    type: "PlayCover",
+    address: stored.address,
+    uuid: stored.uuid,
+  }
+}
+
+function buildDeviceFromAddress(
+  address: string,
+  type: DeviceControllerType,
+): ConnectableDevice | null {
+  if (type === "Adb") {
+    return {
+      type: "Adb",
+      name: address,
+      adb_path: "",
+      address,
+      screencap_methods: "",
+      input_methods: "",
+      config: {},
+    }
+  }
+  if (type === "Win32") {
+    const hWnd = Number.parseInt(address, 10)
+    if (Number.isNaN(hWnd)) {
+      return null
+    }
+    return {
+      type: "Win32",
+      hWnd,
+      class_name: "",
+      window_name: "",
+      screencap_methods: 0,
+      input_methods: 0,
+    }
+  }
+  if (type === "Gamepad") {
+    const parts = address.split("|")
+    const hWnd = Number.parseInt(parts[0] ?? "", 10)
+    if (Number.isNaN(hWnd)) {
+      return null
+    }
+    return {
+      type: "Gamepad",
+      hWnd,
+      class_name: "",
+      window_name: "",
+      screencap_methods: 0,
+      gamepad_type: Number.parseInt(parts[1] ?? "0", 10) || 0,
+    }
+  }
+  return null
+}
+
+const deviceOptions = computed<Array<SelectOption | SelectGroupOption>>(() => {
+  const capability = selectedControllerCapability.value
+  const discoveredOptions = availableDevices.value.map((item) => ({
     label: buildDeviceLabel(item),
     value: buildDeviceFingerprint(item),
   }))
+  const recentDevices = settingsStore.settings.panel.recentDevices ?? []
+  const discoveredFingerprints = new Set(discoveredOptions.map((item) => item.value))
+  const recentOptions = recentDevices
+    .filter(
+      (item) => item.type === capability?.type && !discoveredFingerprints.has(item.fingerprint),
+    )
+    .map((item) => ({
+      label: buildStoredDeviceLabel(item),
+      value: item.fingerprint,
+    }))
+
+  const options: Array<SelectOption | SelectGroupOption> = []
+  if (recentOptions.length > 0) {
+    options.push({
+      type: "group",
+      label: t("panel.recentDevices"),
+      key: "recent-devices",
+      children: recentOptions,
+    })
+  }
+  if (discoveredOptions.length > 0) {
+    options.push({
+      type: "group",
+      label: t("panel.discoveredDevices"),
+      key: "discovered-devices",
+      children: discoveredOptions,
+    })
+  }
+  if (options.length === 0) {
+    return [{ label: t("panel.noDevice"), value: "none-device", disabled: true }]
+  }
+  return options
 })
 
-const selectedDevice = computed(() => {
+const selectedDevice = computed<ConnectableDevice | null>(() => {
   if (!selectedDeviceKey.value) {
     return null
   }
-  return (
-    availableDevices.value.find(
-      (item) => buildDeviceFingerprint(item) === selectedDeviceKey.value,
-    ) || null
+  const discovered = availableDevices.value.find(
+    (item) => buildDeviceFingerprint(item) === selectedDeviceKey.value,
   )
+  if (discovered) {
+    return discovered
+  }
+  const recent = (settingsStore.settings.panel.recentDevices ?? []).find(
+    (item) => item.fingerprint === selectedDeviceKey.value,
+  )
+  if (recent) {
+    return buildConnectableDeviceFromStored(recent)
+  }
+  // Handle custom-typed address (not in discovered or recent list)
+  const capability = selectedControllerCapability.value
+  if (!capability) {
+    return null
+  }
+  return buildDeviceFromAddress(selectedDeviceKey.value, capability.type)
 })
 
 const currentSelectionFingerprint = computed(() => {
@@ -269,6 +413,7 @@ async function persistLastConnectedDevice(deviceInfo: ConnectableDevice, control
   }
 
   await settingsStore.updateSetting("panel", "lastConnectedDevice", storedDevice)
+  return storedDevice
 }
 
 async function persistLastResource(name: string) {
@@ -305,6 +450,8 @@ function restoreLastConnectedDevice() {
 function applyDeviceRuntimeState(state: Awaited<ReturnType<typeof getDeviceState>>) {
   indexStore.setConnected(state.connected)
   isDeviceResourceLocked.value = state.connected ? state.configuration_locked : false
+  connectedControllerName.value = state.controller_name
+  connectedResourceName.value = state.resource_name
 }
 
 async function syncDeviceRuntimeState() {
@@ -358,6 +505,8 @@ function handleControllerChange() {
     return
   }
   selectedDeviceKey.value = null
+  resource.value = null
+  resourcesList.value = []
   const capability = controllerCapabilities.value.find(
     (item) => item.display_label === selectedController.value,
   )
@@ -365,6 +514,7 @@ function handleControllerChange() {
     playCoverAddress.value = getPlayCoverDefaultAddress(controllerCapabilities.value)
   }
   void fetchDevices(capability?.name)
+  void getResourceList()
 }
 
 function refreshDevices() {
@@ -378,27 +528,24 @@ function refreshDevices() {
   void fetchDevices(selectedControllerCapability.value.name)
 }
 
-async function connectDevices() {
+async function connectDevices(): Promise<PostDeviceResult> {
   if (isDeviceResourceLocked.value) {
-    return
+    return { success: false, message: "设备与资源已锁定，无法切换" }
   }
   const selectedCapability = selectedControllerCapability.value
   if (!selectedCapability || selectedControllerDisabled.value) {
-    message.error(t("panel.selectDeviceType"))
-    return
+    return { success: false, message: t("panel.selectDeviceType") }
   }
 
   let currentDevice: ConnectableDevice | null = null
   if (selectedCapability.type === "PlayCover") {
     const address = playCoverAddress.value.trim()
     if (!address) {
-      message.error(t("panel.playcoverAddress"))
-      return
+      return { success: false, message: t("panel.playcoverAddress") }
     }
     const regex = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}:\d{1,5}$/
     if (!regex.test(address)) {
-      message.error(t("panel.invalidPlaycoverAddress"))
-      return
+      return { success: false, message: t("panel.invalidPlaycoverAddress") }
     }
     currentDevice = { type: "PlayCover", address }
   } else {
@@ -406,34 +553,37 @@ async function connectDevices() {
   }
 
   if (!currentDevice) {
-    message.error(t("panel.selectDevice"))
-    return
+    return { success: false, message: t("panel.selectDevice") }
   }
 
-  const success = await postDevices({
+  const result = await postDevices({
     controller_name: selectedCapability.name,
     device: currentDevice,
   })
-  indexStore.setConnected(success)
-  if (success) {
-    await persistLastConnectedDevice(currentDevice, selectedCapability.name)
+  indexStore.setConnected(result.success)
+  if (result.success) {
+    const storedDevice = await persistLastConnectedDevice(currentDevice, selectedCapability.name)
+    if (storedDevice) {
+      await settingsStore.addRecentDevice(storedDevice)
+    }
     await getResourceList()
     await syncDeviceRuntimeState()
   }
+  return result
 }
 
 async function getResourceList() {
-  if (isDeviceResourceLocked.value || !isCurrentSelectionConnected.value) {
+  if (isDeviceResourceLocked.value || !selectedControllerCapability.value) {
     return
   }
 
   resourcesList.value = []
   loading.value = true
   try {
-    const resourceData = await getResource()
-    resourcesList.value = resourceData.map((item) => ({ label: item, value: item }))
+    const resourceData = await getResource(selectedControllerCapability.value.type)
+    resourcesList.value = resourceData.map((item) => ({ label: item.name, value: item.name }))
     const savedResource = settingsStore.settings.panel.lastResource
-    if (savedResource && resourceData.includes(savedResource)) {
+    if (savedResource && resourceData.some((item) => item.name === savedResource)) {
       resource.value = savedResource
     }
   } finally {
@@ -441,24 +591,23 @@ async function getResourceList() {
   }
 }
 
-async function postResourceSelection() {
+async function postResourceSelection(): Promise<PostResourceResult> {
   if (isDeviceResourceLocked.value) {
-    return
+    return { success: false, message: "设备与资源已锁定，无法切换" }
   }
   if (!isCurrentSelectionConnected.value) {
-    message.error(t("panel.connectFirstHint"))
-    return
+    return { success: false, message: t("panel.connectFirstHint") }
   }
   if (!resource.value) {
-    message.error(t("panel.selectResource"))
-    return
+    return { success: false, message: t("panel.selectResource") }
   }
 
-  const success = await postResource(resource.value)
-  if (success) {
+  const result = await postResource(resource.value)
+  if (result.success) {
     await persistLastResource(resource.value)
     await syncDeviceRuntimeState()
   }
+  return result
 }
 
 watch(
@@ -478,6 +627,7 @@ onMounted(async () => {
 
   const savedDevice = settingsStore.settings.panel.lastConnectedDevice
   await fetchDevices(savedDevice?.controller_name, true)
+  void getResourceList()
 
   deviceStatePollTimer = window.setInterval(() => {
     if (!indexStore.Connected && !isDeviceResourceLocked.value) {
@@ -494,7 +644,29 @@ onUnmounted(() => {
   }
 })
 
-function StartTask() {
+async function StartTask() {
+  await syncDeviceRuntimeState()
+
+  const alreadyConnected =
+    indexStore.Connected &&
+    isDeviceResourceLocked.value &&
+    connectedControllerName.value === selectedControllerName.value &&
+    connectedResourceName.value === resource.value
+
+  if (!alreadyConnected) {
+    const connectResult = await connectDevices()
+    if (!connectResult.success) {
+      showGlobalMessage("error", "设备连接失败: " + connectResult.message)
+      return
+    }
+
+    const resourceResult = await postResourceSelection()
+    if (!resourceResult.success) {
+      showGlobalMessage("error", "资源设置失败: " + resourceResult.message)
+      return
+    }
+  }
+
   const isTaskCompatibleInCurrentContext = (taskId: string) =>
     interfaceStore.isTaskCompatibleByEntry(taskId, selectedControllerName.value, resource.value)
 
@@ -508,9 +680,9 @@ function StartTask() {
 
   if (compatibleTaskIds.length === 0) {
     if (allCompatibleTaskIds.length === 0) {
-      message.error(t("panel.noCompatibleTask"))
+      showGlobalMessage("error", t("panel.noCompatibleTask"))
     } else {
-      message.error(t("panel.selectTask"))
+      showGlobalMessage("error", t("panel.selectTask"))
     }
     return
   }

--- a/front/src/components/settings/dialogs/SchedulerTaskDialog.vue
+++ b/front/src/components/settings/dialogs/SchedulerTaskDialog.vue
@@ -179,18 +179,50 @@
         </n-form-item>
       </template>
 
-      <n-space class="mb-6" :size="12" :wrap="true" justify="space-evenly">
+      <n-divider title-placement="left">
+        {{ t("settings.scheduler.dialog.deviceAndResource") }}
+      </n-divider>
+
+      <n-form-item :label="t('settings.scheduler.dialog.controller')" path="controller_name">
         <n-select
-          v-model:value="selectedControllerFilter"
-          :options="controllerFilterOptions"
-          class="min-w-[20rem]"
+          v-model:value="formData.controller_name"
+          :placeholder="t('panel.selectDeviceType')"
+          :options="deviceControllerOptions"
+          :loading="loadingDevices"
+          clearable
+        />
+      </n-form-item>
+
+      <n-form-item :label="t('settings.scheduler.dialog.deviceAddress')" path="device">
+        <n-input
+          v-if="isPlayCover"
+          v-model:value="selectedDeviceAddress"
+          :placeholder="t('panel.playcoverAddress')"
+          :disabled="!formData.controller_name"
         />
         <n-select
-          v-model:value="selectedResourceFilter"
-          :options="resourceFilterOptions"
-          class="min-w-[20rem]"
+          v-else
+          v-model:value="selectedDeviceAddress"
+          :placeholder="t('panel.selectDevice')"
+          :options="deviceAddressOptions"
+          :loading="loadingDevices"
+          :disabled="!formData.controller_name"
+          filterable
+          tag
+          clearable
         />
-      </n-space>
+      </n-form-item>
+
+      <n-form-item :label="t('settings.scheduler.dialog.resource')" path="resource_name">
+        <n-select
+          v-model:value="formData.resource_name"
+          :placeholder="t('panel.selectResource')"
+          :options="resourceOptions"
+          :loading="loadingResources"
+          :disabled="!formData.controller_name"
+          clearable
+        />
+      </n-form-item>
 
       <n-tabs v-model:value="activeTab" type="segment" animated>
         <!-- Tab 1: 前置任务 -->
@@ -206,8 +238,8 @@
             <TaskSelectList
               :tasks="taskListData"
               :selected-tasks="formData.task_list"
-              :controller-name="selectedControllerFilter"
-              :resource-name="selectedResourceFilter"
+              :controller-name="formData.controller_name"
+              :resource-name="formData.resource_name"
               :hide-incompatible="true"
               @update:tasks="handleTasksUpdate"
               @update:selected-tasks="handleSelectedTasksUpdate"
@@ -256,6 +288,10 @@ import TaskSelectList from "@/components/panel/task/TaskSelectList.vue"
 import TaskOptionPanel from "@/components/panel/task/TaskOptionPanel.vue"
 import PreTaskList from "@/components/panel/task/PreTaskList.vue"
 import { resolveInterfaceText } from "@/utils/interface/content"
+import { getDevices } from "@/services/api"
+import type { ConnectableDevice, DeviceControllerType } from "@/services/api"
+import { buildDeviceLabel } from "@/utils/panel/device"
+import type { PanelLastConnectedDevice } from "@/types/settings/model"
 import type {
   ScheduledTask,
   ScheduledTaskCreate,
@@ -291,9 +327,19 @@ const loading = ref(false)
 
 const activeTab = ref<"task-list" | "task-settings" | "pre-tasks">("task-list")
 const currentSettingTaskId = ref<string | null>(null)
-const selectedControllerFilter = ref<string | null>(null)
-const selectedResourceFilter = ref<string | null>(null)
-const suppressFilterSelectionCleanup = ref(false)
+const suppressFormInit = ref(false)
+
+const availableDevices = ref<ConnectableDevice[]>([])
+const availableResources = ref<Array<{ name: string; label?: string; controller?: string[] }>>([])
+const loadingDevices = ref(false)
+const loadingResources = ref(false)
+
+const SUPPORTED_DEVICE_TYPES = new Set<DeviceControllerType>([
+  "Adb",
+  "Win32",
+  "Gamepad",
+  "PlayCover",
+])
 
 const showDialog = computed({
   get: () => props.show,
@@ -303,20 +349,57 @@ const showDialog = computed({
 const isEditMode = computed(() => !!props.task)
 const availableTasks = computed(() => configStore.taskList)
 
-const controllerFilterOptions = computed(() =>
-  (interfaceStore.interface?.controller || []).map((controller) => ({
-    label: resolveInterfaceText(
-      interfaceStore.interface,
-      locale.value,
-      controller.label,
-      controller.name,
-    ),
-    value: controller.name,
-  })),
+const selectedControllerType = computed(() => {
+  const controller = interfaceStore.interface?.controller?.find(
+    (item) => item.name === formData.value.controller_name,
+  )
+  return controller?.type || null
+})
+
+const isPlayCover = computed(() => selectedControllerType.value === "PlayCover")
+
+const deviceControllerOptions = computed(() =>
+  (interfaceStore.interface?.controller || [])
+    .filter((controller) => SUPPORTED_DEVICE_TYPES.has(controller.type as DeviceControllerType))
+    .map((controller) => ({
+      label: resolveInterfaceText(
+        interfaceStore.interface,
+        locale.value,
+        controller.label,
+        controller.name,
+      ),
+      value: controller.name,
+    })),
 )
 
-const resourceFilterOptions = computed(() =>
-  (interfaceStore.interface?.resource || []).map((resource) => ({
+const deviceAddressOptions = computed(() => {
+  if (!formData.value.controller_name) {
+    return []
+  }
+
+  const options = new Map<string, { label: string; value: string }>()
+  for (const device of availableDevices.value) {
+    const value = getDeviceAddressValue(device)
+    options.set(value, { label: buildDeviceLabel(device), value })
+  }
+
+  const recentDevices = settingsStore.settings.panel.recentDevices ?? []
+  for (const device of recentDevices) {
+    if (device.controller_name !== formData.value.controller_name) {
+      continue
+    }
+    const value = getStoredDeviceAddress(device)
+    if (options.has(value)) {
+      continue
+    }
+    options.set(value, { label: buildStoredDeviceLabel(device), value })
+  }
+
+  return Array.from(options.values())
+})
+
+const resourceOptions = computed(() =>
+  availableResources.value.map((resource) => ({
     label: resolveInterfaceText(
       interfaceStore.interface,
       locale.value,
@@ -326,6 +409,24 @@ const resourceFilterOptions = computed(() =>
     value: resource.name,
   })),
 )
+
+const selectedDeviceAddress = computed<string | null>({
+  get: () => formData.value.device?.device_address ?? null,
+  set: (value) => {
+    const controller = interfaceStore.interface?.controller?.find(
+      (item) => item.name === formData.value.controller_name,
+    )
+    if (!controller || !value) {
+      formData.value.device = null
+      return
+    }
+    formData.value.device = {
+      controller_name: controller.name,
+      device_type: controller.type as DeviceControllerType,
+      device_address: value,
+    }
+  },
+})
 
 // 触发器配置的 computed 属性
 const cronConfig = computed(() => formData.value.trigger_config as CronTriggerConfig)
@@ -420,51 +521,70 @@ watch(
 watch(
   () => props.task,
   (task) => {
+    suppressFormInit.value = true
     formData.value = initFormData(task)
     syncTaskListData(formData.value.task_list)
-    resetFilterContext()
+    void nextTick(() => {
+      suppressFormInit.value = false
+    })
   },
 )
 
 watch(
-  () => showDialog.value,
-  (show) => {
-    if (show) {
-      resetFilterContext()
+  () => formData.value.controller_name,
+  (newVal, oldVal) => {
+    const controller = interfaceStore.interface?.controller?.find((item) => item.name === newVal)
+    const type = controller?.type
+
+    if (!suppressFormInit.value && oldVal != null && oldVal !== newVal) {
+      formData.value.device = null
+      formData.value.resource_name = undefined
+    }
+
+    if (newVal && type) {
+      void fetchDevices(newVal)
+      void fetchResources(type)
+    } else {
+      availableDevices.value = []
+      availableResources.value = []
     }
   },
 )
 
-watch([selectedControllerFilter, selectedResourceFilter], ([controllerName, resourceName]) => {
-  if (!showDialog.value || suppressFilterSelectionCleanup.value) {
-    return
-  }
+watch(
+  [() => formData.value.controller_name, () => formData.value.resource_name],
+  ([controllerName, resourceName]) => {
+    if (!showDialog.value || suppressFormInit.value) {
+      return
+    }
 
-  const compatibleTaskIds = formData.value.task_list.filter((taskId) =>
-    interfaceStore.isTaskCompatibleByEntry(taskId, controllerName, resourceName),
-  )
-  const removedCount = formData.value.task_list.length - compatibleTaskIds.length
-  if (removedCount <= 0) {
-    return
-  }
+    const compatibleTaskIds = formData.value.task_list.filter((taskId) =>
+      interfaceStore.isTaskCompatibleByEntry(taskId, controllerName, resourceName),
+    )
+    const removedCount = formData.value.task_list.length - compatibleTaskIds.length
+    if (removedCount <= 0) {
+      return
+    }
 
-  formData.value.task_list = compatibleTaskIds
-  formData.value.task_options = configStore.buildOptionsForTasks(
-    compatibleTaskIds,
-    formData.value.task_options,
-  )
+    formData.value.task_list = compatibleTaskIds
+    formData.value.task_options = configStore.buildOptionsForTasks(
+      compatibleTaskIds,
+      formData.value.task_options,
+    )
 
-  if (currentSettingTaskId.value && !compatibleTaskIds.includes(currentSettingTaskId.value)) {
-    currentSettingTaskId.value = null
-    activeTab.value = "task-list"
-  }
+    if (currentSettingTaskId.value && !compatibleTaskIds.includes(currentSettingTaskId.value)) {
+      currentSettingTaskId.value = null
+      activeTab.value = "task-list"
+    }
 
-  message.warning(
-    t("settings.scheduler.dialog.removedIncompatibleTasks", {
-      count: removedCount,
-    }),
-  )
-})
+    message.warning(
+      t("settings.scheduler.dialog.removedIncompatibleTasks", {
+        count: removedCount,
+      }),
+    )
+  },
+  { flush: "post" },
+)
 
 // 监听可用任务变化，更新可拖拽任务列表
 watch(
@@ -478,30 +598,8 @@ watch(
 function resetForm() {
   formData.value = initFormData()
   syncTaskListData(formData.value.task_list)
-  resetFilterContext()
   currentSettingTaskId.value = null
   activeTab.value = "task-list"
-}
-
-function resetFilterContext() {
-  const availableControllerNames = new Set(
-    (interfaceStore.interface?.controller || []).map((controller) => controller.name),
-  )
-  const availableResourceNames = new Set(
-    (interfaceStore.interface?.resource || []).map((resource) => resource.name),
-  )
-
-  const savedController = settingsStore.settings.panel.lastConnectedDevice?.controller_name || null
-  const savedResource = settingsStore.settings.panel.lastResource || null
-
-  suppressFilterSelectionCleanup.value = true
-  selectedControllerFilter.value =
-    savedController && availableControllerNames.has(savedController) ? savedController : null
-  selectedResourceFilter.value =
-    savedResource && availableResourceNames.has(savedResource) ? savedResource : null
-  void nextTick(() => {
-    suppressFilterSelectionCleanup.value = false
-  })
 }
 
 function syncTaskListData(preferredOrder: string[]) {
@@ -549,6 +647,9 @@ function initFormData(task?: ScheduledTask | null): ScheduledTaskCreate {
       task_list,
       task_options: configStore.buildOptionsForTasks(task_list, task.task_options),
       preTasks: Array.isArray(task.preTasks) ? task.preTasks.map((pt) => ({ ...pt })) : [],
+      controller_name: task.controller_name,
+      device: task.device ? { ...task.device } : null,
+      resource_name: task.resource_name,
     }
   }
   return {
@@ -560,6 +661,9 @@ function initFormData(task?: ScheduledTask | null): ScheduledTaskCreate {
     task_list: [],
     task_options: configStore.buildOptionsForTasks([]),
     preTasks: [],
+    controller_name: undefined,
+    device: null,
+    resource_name: undefined,
   }
 }
 
@@ -635,6 +739,75 @@ function openTaskSettings(taskId: string) {
   }
   currentSettingTaskId.value = taskId
   activeTab.value = "task-settings"
+}
+
+function getDeviceAddressValue(device: ConnectableDevice): string {
+  if (device.type === "Adb") {
+    return device.address
+  }
+  if (device.type === "Win32") {
+    return String(device.hWnd)
+  }
+  if (device.type === "Gamepad") {
+    return `${device.hWnd}|${device.gamepad_type}`
+  }
+  return device.address
+}
+
+function getStoredDeviceAddress(device: PanelLastConnectedDevice): string {
+  if (device.type === "Adb") {
+    return device.address
+  }
+  if (device.type === "Win32") {
+    return String(device.hWnd)
+  }
+  if (device.type === "Gamepad") {
+    return `${device.hWnd}|${device.gamepad_type}`
+  }
+  return device.address
+}
+
+function buildStoredDeviceLabel(device: PanelLastConnectedDevice): string {
+  if (device.type === "Adb") {
+    return device.address
+  }
+  if (device.type === "Win32" || device.type === "Gamepad") {
+    const name = device.window_name || device.class_name
+    return name ? `${name} (${device.hWnd})` : String(device.hWnd)
+  }
+  return device.address
+}
+
+async function fetchDevices(controllerName: string) {
+  loadingDevices.value = true
+  try {
+    const data = await getDevices(controllerName)
+    availableDevices.value = data.devices
+  } catch (error) {
+    console.error("Failed to fetch devices:", error)
+    availableDevices.value = []
+  } finally {
+    loadingDevices.value = false
+  }
+}
+
+async function fetchResources(controllerType: string) {
+  loadingResources.value = true
+  try {
+    const response = await fetch(
+      `/api/resource?controller_type=${encodeURIComponent(controllerType)}`,
+    )
+    const data = (await response.json()) as {
+      status: string
+      resource: Array<{ name: string; label?: string; controller?: string[] }>
+    }
+    availableResources.value = data.status === "success" ? data.resource || [] : []
+  } catch (error) {
+    console.error("Failed to fetch resources:", error)
+    availableResources.value = []
+  } finally {
+    loadingResources.value = false
+  }
 }
 
 async function handleSave() {

--- a/front/src/components/settings/dialogs/SchedulerTaskDialog.vue
+++ b/front/src/components/settings/dialogs/SchedulerTaskDialog.vue
@@ -288,7 +288,7 @@ import TaskSelectList from "@/components/panel/task/TaskSelectList.vue"
 import TaskOptionPanel from "@/components/panel/task/TaskOptionPanel.vue"
 import PreTaskList from "@/components/panel/task/PreTaskList.vue"
 import { resolveInterfaceText } from "@/utils/interface/content"
-import { getDevices } from "@/services/api"
+import { getDevices, getResource } from "@/services/api"
 import type { ConnectableDevice, DeviceControllerType } from "@/services/api"
 import { buildDeviceLabel } from "@/utils/panel/device"
 import type { PanelLastConnectedDevice } from "@/types/settings/model"
@@ -794,14 +794,7 @@ async function fetchDevices(controllerName: string) {
 async function fetchResources(controllerType: string) {
   loadingResources.value = true
   try {
-    const response = await fetch(
-      `/api/resource?controller_type=${encodeURIComponent(controllerType)}`,
-    )
-    const data = (await response.json()) as {
-      status: string
-      resource: Array<{ name: string; label?: string; controller?: string[] }>
-    }
-    availableResources.value = data.status === "success" ? data.resource || [] : []
+    availableResources.value = await getResource(controllerType)
   } catch (error) {
     console.error("Failed to fetch resources:", error)
     availableResources.value = []

--- a/front/src/services/api/modules/device.ts
+++ b/front/src/services/api/modules/device.ts
@@ -1,5 +1,9 @@
-import { showGlobalMessage } from "@/services/feedback/message"
 import type { ApiResponse } from "@/services/api/core/types"
+
+export interface PostDeviceResult {
+  success: boolean
+  message: string
+}
 
 export type DeviceControllerType = "Adb" | "Win32" | "Gamepad" | "PlayCover"
 
@@ -86,7 +90,7 @@ export function getDevices(controllerName?: string): Promise<DeviceSearchData> {
     .then((data: DeviceResponse) => data.data)
 }
 
-export function postDevices(payload: ConnectDevicePayload): Promise<boolean> {
+export function postDevices(payload: ConnectDevicePayload): Promise<PostDeviceResult> {
   return fetch("/api/device", {
     method: "POST",
     body: JSON.stringify({
@@ -100,11 +104,13 @@ export function postDevices(payload: ConnectDevicePayload): Promise<boolean> {
     .then((res) => res.json())
     .then((data: ApiResponse) => {
       if (data.status === "success") {
-        showGlobalMessage("success", "设备连接成功")
-        return true
+        return { success: true, message: "设备连接成功" }
       }
-      showGlobalMessage("error", "设备连接失败，请检查终端日志")
-      return false
+      return { success: false, message: data.message || "设备连接失败，请检查终端日志" }
+    })
+    .catch((error) => {
+      console.error("Failed to connect device:", error)
+      return { success: false, message: "网络错误，请稍后重试" }
     })
 }
 

--- a/front/src/services/api/modules/resource.ts
+++ b/front/src/services/api/modules/resource.ts
@@ -1,13 +1,25 @@
-import { showGlobalMessage } from "@/services/feedback/message"
 import type { ApiResponse } from "@/services/api/core/types"
+import { showGlobalMessage } from "@/services/feedback/message"
+
+export interface PostResourceResult {
+  success: boolean
+  message: string
+}
+
+export interface ResourceInfo {
+  name: string
+  label?: string | null
+  controller?: string[] | null
+}
 
 interface ResourceResponse {
   status: string
-  resource: string[]
+  resource: ResourceInfo[]
 }
 
-export function getResource(): Promise<string[]> {
-  return fetch("/api/resource", { method: "GET" })
+export function getResource(controllerType?: string): Promise<ResourceInfo[]> {
+  const query = controllerType ? `?controller_type=${encodeURIComponent(controllerType)}` : ""
+  return fetch(`/api/resource${query}`, { method: "GET" })
     .then((res) => res.json())
     .then((data: ResourceResponse & ApiResponse) => {
       if (data.status !== "success") {
@@ -18,7 +30,7 @@ export function getResource(): Promise<string[]> {
     })
 }
 
-export function postResource(name: string): Promise<boolean> {
+export function postResource(name: string): Promise<PostResourceResult> {
   return fetch("/api/resource?name=" + name, {
     method: "POST",
     headers: {
@@ -28,15 +40,12 @@ export function postResource(name: string): Promise<boolean> {
     .then((res) => res.json())
     .then((data: ApiResponse) => {
       if (data.status === "success") {
-        showGlobalMessage("success", "资源添加成功")
-        return true
+        return { success: true, message: "资源添加成功" }
       }
-      showGlobalMessage("error", data.message || "资源设置失败")
-      return false
+      return { success: false, message: data.message || "资源设置失败" }
     })
     .catch((error) => {
       console.error("Failed to set resource:", error)
-      showGlobalMessage("error", "网络错误，请稍后重试")
-      return false
+      return { success: false, message: "网络错误，请稍后重试" }
     })
 }

--- a/front/src/services/api/modules/resource.ts
+++ b/front/src/services/api/modules/resource.ts
@@ -31,7 +31,7 @@ export function getResource(controllerType?: string): Promise<ResourceInfo[]> {
 }
 
 export function postResource(name: string): Promise<PostResourceResult> {
-  return fetch("/api/resource?name=" + name, {
+  return fetch("/api/resource?name=" + encodeURIComponent(name), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/front/src/stores/settings/settings.ts
+++ b/front/src/stores/settings/settings.ts
@@ -31,6 +31,7 @@ const defaultSettings: SettingsModel = {
     reminderInterval: 30,
     autoRetry: true,
     maxRetryCount: 3,
+    retryInterval: 5,
   },
   about: {
     version: "",
@@ -44,6 +45,7 @@ const defaultSettings: SettingsModel = {
   panel: {
     lastResource: "",
     lastConnectedDevice: null,
+    recentDevices: [],
   },
 }
 

--- a/front/src/stores/settings/settings.ts
+++ b/front/src/stores/settings/settings.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia"
 import { getSettings, updateSettings } from "@/services/api"
-import type { SettingsModel } from "@/types/settings/model"
+import type { PanelLastConnectedDevice, SettingsModel } from "@/types/settings/model"
 
 const defaultSettings: SettingsModel = {
   update: {
@@ -113,6 +113,7 @@ export const useSettingsStore = defineStore("settings", {
               ...defaultSettings.panel,
               ...data.panel,
               lastConnectedDevice: data.panel?.lastConnectedDevice ?? null,
+              recentDevices: data.panel?.recentDevices ?? [],
             },
           }
           // 确保本地缓存与服务器设置同步
@@ -166,6 +167,23 @@ export const useSettingsStore = defineStore("settings", {
 
       // 后台保存
       return this.saveSettings(updatedSettings)
+    },
+
+    addRecentDevice(deviceConfig: PanelLastConnectedDevice) {
+      const list = this.settings.panel.recentDevices ?? []
+      // Deduplicate: remove existing entry with same fingerprint
+      const filtered = list.filter((d) => d.fingerprint !== deviceConfig.fingerprint)
+      // Add most recent first
+      filtered.unshift(deviceConfig)
+      // Keep max 5
+      this.settings.panel.recentDevices = filtered.slice(0, 5)
+      return this.saveSettings()
+    },
+
+    removeRecentDevice(fingerprint: string) {
+      const list = this.settings.panel.recentDevices ?? []
+      this.settings.panel.recentDevices = list.filter((d) => d.fingerprint !== fingerprint)
+      return this.saveSettings()
     },
 
     async resetSettings() {

--- a/front/src/types/scheduler/model.ts
+++ b/front/src/types/scheduler/model.ts
@@ -36,6 +36,12 @@ export interface TaskExecutionPayload {
   preTasks: PreTaskCommand[]
 }
 
+export interface ScheduledTaskDeviceConfig {
+  controller_name: string
+  device_type: "Adb" | "Win32" | "Gamepad" | "PlayCover"
+  device_address: string
+}
+
 export interface ScheduledTask extends TaskExecutionPayload {
   id: string
   name: string
@@ -43,6 +49,9 @@ export interface ScheduledTask extends TaskExecutionPayload {
   enabled: boolean
   trigger_type: TriggerType
   trigger_config: TriggerConfig
+  controller_name?: string
+  device?: ScheduledTaskDeviceConfig | null
+  resource_name?: string
   next_run_time?: string // ISO 8601 datetime string
   created_at: string // ISO 8601 datetime string
   updated_at: string // ISO 8601 datetime string
@@ -54,6 +63,9 @@ export interface ScheduledTaskCreate extends TaskExecutionPayload {
   enabled: boolean
   trigger_type: TriggerType
   trigger_config: TriggerConfig
+  controller_name?: string
+  device?: ScheduledTaskDeviceConfig | null
+  resource_name?: string
 }
 
 export interface ScheduledTaskUpdate {
@@ -62,6 +74,9 @@ export interface ScheduledTaskUpdate {
   enabled?: boolean
   trigger_type?: TriggerType
   trigger_config?: TriggerConfig
+  controller_name?: string
+  device?: ScheduledTaskDeviceConfig | null
+  resource_name?: string
   task_list?: string[]
   task_options?: TaskOptionsByTask
   preTasks?: PreTaskCommand[]

--- a/front/src/types/settings/model.ts
+++ b/front/src/types/settings/model.ts
@@ -33,6 +33,7 @@ export interface RuntimeSettings {
   reminderInterval: number
   autoRetry: boolean
   maxRetryCount: number
+  retryInterval: number
 }
 
 // 关于我们（包含联系方式）
@@ -64,6 +65,7 @@ export interface PanelLastConnectedDevice {
 export interface PanelSettings {
   lastResource: string
   lastConnectedDevice: PanelLastConnectedDevice | null
+  recentDevices: PanelLastConnectedDevice[] | null
 }
 
 // 完整设置模型

--- a/maa_worker/device_service.py
+++ b/maa_worker/device_service.py
@@ -300,6 +300,85 @@ class DeviceService:
             if state_changed:
                 self.worker.events.send_log(reason)
 
+    @staticmethod
+    def build_device_model_from_config(
+        controller_name: str, device_type: str, device_address: str
+    ) -> DeviceModel:
+        """从简化设备配置构造 DeviceModel。
+
+        由调度器使用，在执行定时任务前根据存储的设备配置构造 DeviceModel，
+        然后传递给 connect() 进行实际连接。
+
+        Args:
+            controller_name: 控制器名称（来自 interface.json 的 controller name）
+            device_type: 设备类型 ("Adb", "Win32", "Gamepad", "PlayCover")
+            device_address: 设备地址（格式因类型而异）
+                - Adb: IP:PORT 地址，如 "127.0.0.1:5555"
+                - Win32: hWnd 的字符串形式，如 "123456"
+                - Gamepad: "hWnd|gamepad_type" 格式，如 "123456|1"
+                - PlayCover: IP:PORT 地址，如 "127.0.0.1:1717"
+
+        Returns:
+            构造好的 DeviceModel 实例
+
+        Raises:
+            ValueError: 不支持的设备类型
+        """
+        if device_type == "Adb":
+            return DeviceModel(
+                type="Adb",
+                controller_name=controller_name,
+                name=device_address,
+                address=device_address,
+                adb_path="",
+                screencap_methods=0,
+                input_methods=0,
+                config={},
+            )
+        elif device_type == "Win32":
+            try:
+                hwnd = int(device_address)
+            except (ValueError, TypeError):
+                hwnd = 0
+            return DeviceModel(
+                type="Win32",
+                controller_name=controller_name,
+                name=device_address,
+                hWnd=hwnd,
+                screencap_methods=0,
+                input_methods=0,
+            )
+        elif device_type == "Gamepad":
+            parts = device_address.split("|", 1)
+            try:
+                hwnd = int(parts[0]) if parts else 0
+            except (ValueError, TypeError):
+                hwnd = 0
+            gamepad_type = 0
+            if len(parts) > 1:
+                try:
+                    gamepad_type = int(parts[1])
+                except (ValueError, TypeError):
+                    gamepad_type = 0
+            return DeviceModel(
+                type="Gamepad",
+                controller_name=controller_name,
+                name=device_address,
+                hWnd=hwnd,
+                gamepad_type=gamepad_type,
+                screencap_methods=0,
+            )
+        elif device_type == "PlayCover":
+            return DeviceModel(
+                type="PlayCover",
+                controller_name=controller_name,
+                name=device_address,
+                address=device_address,
+                uuid="",
+            )
+        else:
+            raise ValueError(f"不支持的设备类型: {device_type}")
+
     def connect(self, device_config: DeviceModel) -> bool:
         state = self.worker.device_state
         if state.configuration_locked:

--- a/maa_worker/resource_utils.py
+++ b/maa_worker/resource_utils.py
@@ -1,0 +1,66 @@
+import sys
+from typing import Any
+
+
+def _get_app_state():
+    """Access the AppState instance from the entry-point module.
+
+    ``main.py`` creates ``app_state = AppState()`` at module level;
+    this helper retrieves it via ``sys.modules["__main__"]`` to avoid
+    circular imports or duplicating the singleton in ``app_state.py``.
+    """
+    main_mod = sys.modules.get("__main__")
+    if main_mod is None:
+        return None
+    return getattr(main_mod, "app_state", None)
+
+
+def filter_resources_by_controller_type(
+    resources: list[dict[str, Any]], controller_type: str
+) -> list[dict[str, Any]]:
+    """Filter resource dicts by controller type.
+
+    Returns resources whose ``controller`` field is *None* (compatible
+    with all), empty, or contains at least one controller name matching
+    the given type.
+
+    Controller-name-to-type mapping is resolved from the loaded
+    interface (``InterfaceModel.controller``).  When the interface is
+    not available (e.g. worker not yet initialised) the function falls
+    back to a case-insensitive comparison between *controller_type* and
+    each entry in the resource's controller list.
+    """
+    controller_names: list[str] | None = None
+
+    app_state = _get_app_state()
+    if app_state is not None:
+        worker = getattr(app_state, "worker", None)
+        if worker is not None:
+            interface = getattr(worker, "interface", None)
+            if interface is not None:
+                controllers = getattr(interface, "controller", None)
+                if controllers is not None:
+                    controller_names = [
+                        c.name for c in controllers if c.type == controller_type
+                    ]
+
+    result: list[dict[str, Any]] = []
+    for resource in resources:
+        rc = resource.get("controller")
+
+        # None or empty list → compatible with all controller types
+        if not rc:
+            result.append(resource)
+            continue
+
+        if controller_names is not None:
+            # Interface was available — match against known names
+            if any(name in controller_names for name in rc):
+                result.append(resource)
+        else:
+            # Fallback: case-insensitive comparison
+            ct_lower = controller_type.lower()
+            if any(name.lower() == ct_lower for name in rc):
+                result.append(resource)
+
+    return result

--- a/maa_worker/resource_utils.py
+++ b/maa_worker/resource_utils.py
@@ -6,13 +6,17 @@ def _get_app_state():
     """Access the AppState instance from the entry-point module.
 
     ``main.py`` creates ``app_state = AppState()`` at module level;
-    this helper retrieves it via ``sys.modules["__main__"]`` to avoid
-    circular imports or duplicating the singleton in ``app_state.py``.
+    this helper retrieves it via ``sys.modules`` to avoid circular
+    imports or duplicating the singleton in ``app_state.py``.
+
+    Checks both ``__main__`` (direct ``python main.py`` / ``uv run main.py``)
+    and ``main`` (``uvicorn main:app``) execution modes.
     """
-    main_mod = sys.modules.get("__main__")
-    if main_mod is None:
-        return None
-    return getattr(main_mod, "app_state", None)
+    for mod_name in ("__main__", "main"):
+        main_mod = sys.modules.get(mod_name)
+        if main_mod is not None and hasattr(main_mod, "app_state"):
+            return main_mod.app_state
+    return None
 
 
 def filter_resources_by_controller_type(
@@ -26,9 +30,9 @@ def filter_resources_by_controller_type(
 
     Controller-name-to-type mapping is resolved from the loaded
     interface (``InterfaceModel.controller``).  When the interface is
-    not available (e.g. worker not yet initialised) the function falls
-    back to a case-insensitive comparison between *controller_type* and
-    each entry in the resource's controller list.
+    not available (e.g. worker not yet initialised) the function skips
+    filtering and returns all resources unchanged to avoid false
+    negatives.
     """
     controller_names: list[str] | None = None
 
@@ -58,9 +62,9 @@ def filter_resources_by_controller_type(
             if any(name in controller_names for name in rc):
                 result.append(resource)
         else:
-            # Fallback: case-insensitive comparison
-            ct_lower = controller_type.lower()
-            if any(name.lower() == ct_lower for name in rc):
-                result.append(resource)
+            # Interface mapping unavailable — cannot reliably match
+            # controller names to types, so keep the resource to avoid
+            # false negatives.
+            result.append(resource)
 
     return result

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 
 import uvicorn
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Query, Request
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
@@ -313,12 +313,25 @@ def get_device_state():
 
 
 @app.get("/api/resource")
-def get_resource():
+def get_resource(controller_type: str | None = Query(default=None)):
     if app_state.worker is None:
         return {"status": "failed", "message": "Worker未初始化"}
-    if not app_state.worker.device_state.connected:
-        return {"status": "failed", "message": "请先连接设备后再选择资源"}
-    return {"status": "success", "resource": [i.name for i in interface.resource]}
+    resources = [
+        {
+            "name": r.name,
+            "label": r.label,
+            "controller": r.controller,
+        }
+        for r in interface.resource
+    ]
+    if controller_type:
+        try:
+            from maa_worker.resource_utils import filter_resources_by_controller_type
+
+            resources = filter_resources_by_controller_type(resources, controller_type)
+        except ImportError:
+            pass
+    return {"status": "success", "resource": resources}
 
 
 @app.post("/api/resource")

--- a/models/scheduler.py
+++ b/models/scheduler.py
@@ -9,6 +9,16 @@ TaskOptionValue = str | List[str] | Dict[str, str]
 TaskOptionsByTask = Dict[str, Dict[str, TaskOptionValue]]
 
 
+class ScheduledTaskDeviceConfig(BaseModel):
+    """定时任务设备配置"""
+
+    controller_name: str = Field(..., description="控制器名称")
+    device_type: Literal["Adb", "Win32", "Gamepad", "PlayCover"] = Field(
+        ..., description="设备类型"
+    )
+    device_address: str = Field(..., description="设备地址")
+
+
 def _generate_pre_task_id() -> str:
     """生成前置命令的唯一标识"""
     return str(uuid.uuid4())
@@ -83,6 +93,9 @@ class ScheduledTask(TaskExecutionPayload):
         ..., description="触发器类型"
     )
     trigger_config: TriggerConfig = Field(..., description="触发器配置")
+    controller_name: Optional[str] = Field(None, description="控制器名称")
+    device: Optional[ScheduledTaskDeviceConfig] = Field(None, description="设备配置")
+    resource_name: Optional[str] = Field(None, description="资源包名称")
     next_run_time: Optional[datetime] = Field(None, description="下次执行时间")
     created_at: datetime = Field(default_factory=datetime.now, description="创建时间")
     updated_at: datetime = Field(default_factory=datetime.now, description="更新时间")
@@ -96,6 +109,9 @@ class ScheduledTaskCreate(TaskExecutionPayload):
     enabled: bool = True
     trigger_type: Literal["cron", "date", "interval"]
     trigger_config: TriggerConfig
+    controller_name: Optional[str] = Field(None, description="控制器名称")
+    device: Optional[ScheduledTaskDeviceConfig] = Field(None, description="设备配置")
+    resource_name: Optional[str] = Field(None, description="资源包名称")
 
 
 class ScheduledTaskUpdate(BaseModel):
@@ -106,6 +122,9 @@ class ScheduledTaskUpdate(BaseModel):
     enabled: Optional[bool] = None
     trigger_type: Optional[Literal["cron", "date", "interval"]] = None
     trigger_config: Optional[TriggerConfig] = None
+    controller_name: Optional[str] = Field(None, description="控制器名称")
+    device: Optional[ScheduledTaskDeviceConfig] = Field(None, description="设备配置")
+    resource_name: Optional[str] = Field(None, description="资源包名称")
     task_list: Optional[List[str]] = None
     task_options: Optional[TaskOptionsByTask] = None
     preTasks: Optional[List[PreTaskCommand]] = None

--- a/models/settings.py
+++ b/models/settings.py
@@ -2,7 +2,7 @@ import re
 from typing import Any, Literal, Optional
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, ValidationInfo, model_validator
+from pydantic import BaseModel, ValidationInfo, field_validator, model_validator
 
 
 def _normalize_str(value: Any) -> str:
@@ -89,6 +89,7 @@ class Runtime(BaseModel):
     reminderInterval: int = 30
     autoRetry: bool = True
     maxRetryCount: int = 3
+    retryInterval: int = 5
 
 
 class About(BaseModel):
@@ -117,6 +118,16 @@ class PanelLastConnectedDevice(BaseModel):
 class Panel(BaseModel):
     lastResource: str = ""
     lastConnectedDevice: Optional[PanelLastConnectedDevice] = None
+    recentDevices: Optional[list[PanelLastConnectedDevice]] = None
+
+    @field_validator("recentDevices")
+    @classmethod
+    def truncate_recent_devices(
+        cls, v: Optional[list[PanelLastConnectedDevice]]
+    ) -> Optional[list[PanelLastConnectedDevice]]:
+        if v is not None and len(v) > 5:
+            return v[:5]
+        return v
 
 
 class SettingsModel(BaseModel):

--- a/scheduler_manager.py
+++ b/scheduler_manager.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional, List, Literal
 
+from pydantic import BaseModel
+
 import aiosqlite
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -12,10 +14,12 @@ from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
+from maa_worker.event_service import load_settings
 from models.task_config import normalize_task_execution_payload
 from models.scheduler import (
     ScheduledTask,
     ScheduledTaskCreate,
+    ScheduledTaskDeviceConfig,
     ScheduledTaskUpdate,
     TaskExecution,
     TaskOptionsByTask,
@@ -37,6 +41,9 @@ async def execute_scheduled_task(
     task_list: List[str],
     task_options: TaskOptionsByTask,
     pre_tasks: Optional[List[dict]] = None,
+    controller_name: Optional[str] = None,
+    device: Optional[dict] = None,
+    resource_name: Optional[str] = None,
 ):
     """APScheduler 可持久化执行入口"""
     if _ACTIVE_MANAGER is None:
@@ -49,6 +56,9 @@ async def execute_scheduled_task(
         task_list=task_list,
         task_options=task_options,
         pre_tasks=pre_tasks or [],
+        controller_name=controller_name,
+        device=device,
+        resource_name=resource_name,
     )
 
 
@@ -188,8 +198,20 @@ class SchedulerManager:
         task_list: List[str],
         task_options: TaskOptionsByTask,
         pre_tasks: Optional[List[dict]] = None,
+        controller_name: Optional[str] = None,
+        device: Optional[dict] = None,
+        resource_name: Optional[str] = None,
     ):
-        """执行定时任务"""
+        """执行定时任务
+
+        自动连接设备并设置资源后执行任务。连接流程：
+        1. 检查任务是否已在运行 → 跳过
+        2. 校验 device/resource_name 配置完整性
+        3. 若已连接到匹配设备且资源一致 → 复用连接
+        4. 若 configuration_locked 但连接不匹配 → reset_connection_state() 解锁
+        5. 构造 DeviceModel，按 maxRetryCount/retryInterval 重试 connect + set_resource
+        6. 连接成功后调用 tasks.start() 并等待完成
+        """
         logger.info(f"开始执行定时任务: {task_id}")
 
         # 创建执行记录
@@ -206,22 +228,111 @@ class SchedulerManager:
         await self._add_execution(execution)
 
         try:
-            # 检查是否有任务正在运行
+            # 1. 检查是否有任务正在运行
             if self._worker and self._worker.task_state.running:
-                logger.warning(f"任务已在运行，跳过定时任务 {task_id}")
+                self._worker.events.send_log(
+                    f"定时任务 {task_id} 已被跳过：任务已在运行"
+                )
                 await self._update_execution_status(
                     execution_id, "stopped", "任务已在运行"
                 )
                 return
 
-            # 检查设备是否已连接
-            if not self._worker or not self._worker.device_state.connected:
-                logger.error(f"设备未连接，无法执行定时任务 {task_id}")
+            if not self._worker:
+                logger.error(f"Worker 未就绪，无法执行定时任务 {task_id}")
                 await self._update_execution_status(
-                    execution_id, "failed", "设备未连接"
+                    execution_id, "failed", "Worker 未就绪"
                 )
                 return
 
+            # 2. 校验设备/资源配置完整性
+            if device is None or resource_name is None:
+                _settings = load_settings()
+                self._worker.events.send_notification(
+                    "配置缺失",
+                    f"定时任务 {task_id} 执行失败：设备或资源配置缺失",
+                    event="task.failed",
+                    level="error",
+                    notify=["notification"]
+                    if _settings.notification.notifyOnError
+                    else [],
+                )
+                await self._update_execution_status(
+                    execution_id, "failed", "设备或资源配置缺失"
+                )
+                return
+
+            # 3. 判断是否已连接到匹配的设备与资源
+            device_state = self._worker.device_state
+            device_controller_name = device.get("controller_name")
+            need_connect = True
+            if (
+                device_state.connected
+                and device_state.configuration_locked
+                and device_state.controller_name == device_controller_name
+                and device_state.current_resource_name == resource_name
+            ):
+                need_connect = False
+
+            # 4. 若配置已锁定但连接不匹配，先解锁
+            if need_connect and device_state.configuration_locked:
+                await asyncio.to_thread(self._worker.devices.reset_connection_state)
+
+            # 5. 构造 DeviceModel 并重试连接
+            if need_connect:
+                device_model = self._worker.devices.build_device_model_from_config(
+                    device_controller_name,
+                    device["device_type"],
+                    device["device_address"],
+                )
+                _settings = load_settings()
+                max_retry = _settings.runtime.maxRetryCount
+                retry_interval = _settings.runtime.retryInterval
+
+                connect_success = False
+                for attempt in range(1, max_retry + 1):
+                    try:
+                        connected = await asyncio.to_thread(
+                            self._worker.devices.connect, device_model
+                        )
+                        if not connected:
+                            raise RuntimeError("connect() 返回 False")
+                        resource_set = await asyncio.to_thread(
+                            self._worker.devices.set_resource, resource_name
+                        )
+                        if not resource_set:
+                            raise RuntimeError("set_resource() 返回 False")
+                        connect_success = True
+                        break
+                    except Exception as e:
+                        if attempt < max_retry:
+                            self._worker.events.send_log(
+                                f"连接失败，第 {attempt} 次重试...: {e}"
+                            )
+                            await asyncio.sleep(retry_interval)
+                        else:
+                            self._worker.events.send_log(
+                                f"连接失败，已达最大重试次数 {max_retry}: {e}"
+                            )
+
+                if not connect_success:
+                    _settings = load_settings()
+                    self._worker.events.send_notification(
+                        "连接失败",
+                        f"定时任务 {task_id} 执行失败：设备连接失败",
+                        event="task.failed",
+                        level="error",
+                        notify=["notification"]
+                        if _settings.notification.notifyOnError
+                        else [],
+                    )
+                    await asyncio.to_thread(self._worker.devices.reset_connection_state)
+                    await self._update_execution_status(
+                        execution_id, "failed", "设备连接失败"
+                    )
+                    return
+
+            # 6. 规范化任务载荷
             normalized_task_list, normalized_task_options, normalized_pre_tasks = (
                 self._normalize_task_payload(
                     task_list,
@@ -237,26 +348,29 @@ class SchedulerManager:
                 )
                 return
 
-            # 启动任务
+            # 7. 启动任务
             if not self._worker.tasks.start(
                 normalized_task_list,
                 normalized_task_options,
                 task_name=task_name,
                 pre_tasks=normalized_pre_tasks,
             ):
-                logger.warning(f"任务已在运行，跳过定时任务 {task_id}")
+                self._worker.events.send_log(
+                    f"定时任务 {task_id} 已被跳过：任务已在运行"
+                )
                 await self._update_execution_status(
                     execution_id, "stopped", "任务已在运行"
                 )
                 return
 
-            # 等待任务完成
+            # 8. 等待任务完成
             while self._worker and self._worker.task_state.running:
                 await asyncio.sleep(1)
 
             task_status = getattr(self._worker.task_state, "last_status", "failed")
             task_error = getattr(self._worker.task_state, "last_error", None)
 
+            # 9. 更新执行记录状态
             if task_status == "success":
                 await self._update_execution_status(execution_id, "success")
                 logger.info(f"定时任务 {task_id} 执行成功")
@@ -264,15 +378,18 @@ class SchedulerManager:
                 await self._update_execution_status(
                     execution_id, "stopped", task_error or "任务已终止"
                 )
-                logger.warning(f"定时任务 {task_id} 已停止")
+                self._worker.events.send_log(f"定时任务 {task_id} 已停止")
             else:
                 await self._update_execution_status(
                     execution_id, "failed", task_error or "任务执行失败"
                 )
                 logger.error(f"定时任务 {task_id} 执行失败: {task_error}")
+                self._worker.events.send_log(f"定时任务 {task_id} 执行失败")
 
         except Exception as e:
             logger.error(f"定时任务 {task_id} 执行失败: {e}")
+            if self._worker:
+                self._worker.events.send_log(f"定时任务 {task_id} 执行异常: {e}")
             await self._update_execution_status(execution_id, "failed", str(e))
 
     def _build_trigger_config(
@@ -416,6 +533,11 @@ class SchedulerManager:
                 "task_list": normalized_task_list,
                 "task_options": normalized_task_options,
                 "pre_tasks": [pt.model_dump() for pt in normalized_pre_tasks],
+                "controller_name": task_create.controller_name,
+                "device": task_create.device.model_dump()
+                if task_create.device
+                else None,
+                "resource_name": task_create.resource_name,
             },
         )
 
@@ -439,6 +561,9 @@ class SchedulerManager:
             task_options=normalized_task_options,
             preTasks=normalized_pre_tasks,
             next_run_time=next_run_time,
+            controller_name=task_create.controller_name,
+            device=task_create.device,
+            resource_name=task_create.resource_name,
         )
 
         logger.info(f"创建定时任务: {task.name} ({task_id})")
@@ -460,12 +585,19 @@ class SchedulerManager:
             job.kwargs.get("task_options", {}),
             job.kwargs.get("preTasks", []) or job.kwargs.get("pre_tasks", []),
         )
+        controller_name = job.kwargs.get("controller_name", None)
+        device_raw = job.kwargs.get("device", None)
+        device = ScheduledTaskDeviceConfig(**device_raw) if device_raw else None
+        resource_name = job.kwargs.get("resource_name", None)
         trigger_type: Literal["cron", "date", "interval"]
 
         try:
             trigger_type, trigger_config = self._build_trigger_config(job.trigger)
         except Exception as e:
-            logger.warning(f"重建触发器配置失败，使用默认 cron 配置: {e}")
+            if self._worker:
+                self._worker.events.send_log(
+                    f"重建触发器配置失败，使用默认 cron 配置: {e}"
+                )
             trigger_type = "cron"
             trigger_config = CronTriggerConfig(cron="* * * * *")
 
@@ -480,6 +612,9 @@ class SchedulerManager:
             task_options=task_options,
             preTasks=pre_tasks,
             next_run_time=job.next_run_time,
+            controller_name=controller_name,
+            device=device,
+            resource_name=resource_name,
         )
 
     async def get_all_tasks(self) -> List[ScheduledTask]:
@@ -497,14 +632,19 @@ class SchedulerManager:
                 job.kwargs.get("task_options", {}),
                 job.kwargs.get("preTasks", []) or job.kwargs.get("pre_tasks", []),
             )
+            controller_name = job.kwargs.get("controller_name", None)
+            device_raw = job.kwargs.get("device", None)
+            device = ScheduledTaskDeviceConfig(**device_raw) if device_raw else None
+            resource_name = job.kwargs.get("resource_name", None)
             trigger_type: Literal["cron", "date", "interval"]
 
             try:
                 trigger_type, trigger_config = self._build_trigger_config(job.trigger)
             except Exception as e:
-                logger.warning(
-                    f"重建任务 {job.id} 的触发器配置失败，使用默认 cron 配置: {e}"
-                )
+                if self._worker:
+                    self._worker.events.send_log(
+                        f"重建任务 {job.id} 的触发器配置失败，使用默认 cron 配置: {e}"
+                    )
                 trigger_type = "cron"
                 trigger_config = CronTriggerConfig(cron="* * * * *")
 
@@ -519,6 +659,9 @@ class SchedulerManager:
                 task_options=task_options,
                 preTasks=pre_tasks,
                 next_run_time=job.next_run_time,
+                controller_name=controller_name,
+                device=device,
+                resource_name=resource_name,
             )
             tasks.append(task)
 
@@ -529,11 +672,29 @@ class SchedulerManager:
     ) -> Optional[ScheduledTask]:
         """更新定时任务"""
         if not self.scheduler:
-            logger.error("调度器未初始化")
+            if self._worker:
+                _settings = load_settings()
+                self._worker.events.send_notification(
+                    "调度器未初始化",
+                    "无法更新定时任务：调度器未初始化",
+                    level="error",
+                    notify=["notification"]
+                    if _settings.notification.notifyOnError
+                    else [],
+                )
             return None
         job = self.scheduler.get_job(task_id)
         if not job:
-            logger.error(f"任务不存在: {task_id}")
+            if self._worker:
+                _settings = load_settings()
+                self._worker.events.send_notification(
+                    "任务不存在",
+                    f"无法更新定时任务：任务 {task_id} 不存在",
+                    level="error",
+                    notify=["notification"]
+                    if _settings.notification.notifyOnError
+                    else [],
+                )
             return None
 
         try:
@@ -543,7 +704,10 @@ class SchedulerManager:
             try:
                 _, current_trigger_config = self._build_trigger_config(job.trigger)
             except Exception as e:
-                logger.warning(f"重建当前触发器配置失败，使用默认 cron 配置: {e}")
+                if self._worker:
+                    self._worker.events.send_log(
+                        f"重建当前触发器配置失败，使用默认 cron 配置: {e}"
+                    )
                 current_trigger_config = CronTriggerConfig(cron="* * * * *")
 
             # 合并更新数据
@@ -572,6 +736,26 @@ class SchedulerManager:
                 if task_update.preTasks is not None
                 else current_kwargs.get("preTasks", [])
                 or current_kwargs.get("pre_tasks", [])
+            )
+            new_controller_name = (
+                task_update.controller_name
+                if task_update.controller_name is not None
+                else current_kwargs.get("controller_name", None)
+            )
+            new_device_raw = (
+                task_update.device
+                if task_update.device is not None
+                else current_kwargs.get("device", None)
+            )
+            new_device = (
+                new_device_raw.model_dump()
+                if isinstance(new_device_raw, BaseModel)
+                else new_device_raw
+            )
+            new_resource_name = (
+                task_update.resource_name
+                if task_update.resource_name is not None
+                else current_kwargs.get("resource_name", None)
             )
             normalized_task_list, normalized_task_options, normalized_pre_tasks = (
                 self._normalize_task_payload(
@@ -603,6 +787,9 @@ class SchedulerManager:
                     "task_list": normalized_task_list,
                     "task_options": normalized_task_options,
                     "preTasks": [pt.model_dump() for pt in normalized_pre_tasks],
+                    "controller_name": new_controller_name,
+                    "device": new_device,
+                    "resource_name": new_resource_name,
                 },
             )
 
@@ -617,6 +804,8 @@ class SchedulerManager:
             return await self.get_task(task_id)
         except Exception as e:
             logger.error(f"更新任务失败: {e}")
+            if self._worker:
+                self._worker.events.send_log(f"更新任务失败: {e}")
             return None
 
     async def delete_task(self, task_id: str) -> bool:
@@ -629,6 +818,8 @@ class SchedulerManager:
             return True
         except Exception as e:
             logger.error(f"删除任务失败: {e}")
+            if self._worker:
+                self._worker.events.send_log(f"删除任务失败: {e}")
             return False
 
     async def pause_task(self, task_id: str) -> bool:
@@ -641,6 +832,8 @@ class SchedulerManager:
             return True
         except Exception as e:
             logger.error(f"暂停任务失败: {e}")
+            if self._worker:
+                self._worker.events.send_log(f"暂停任务失败: {e}")
             return False
 
     async def resume_task(self, task_id: str) -> bool:
@@ -653,6 +846,8 @@ class SchedulerManager:
             return True
         except Exception as e:
             logger.error(f"恢复任务失败: {e}")
+            if self._worker:
+                self._worker.events.send_log(f"恢复任务失败: {e}")
             return False
 
     async def get_executions(self, limit: int = 50) -> List[TaskExecution]:

--- a/scheduler_manager.py
+++ b/scheduler_manager.py
@@ -264,7 +264,7 @@ class SchedulerManager:
 
             # 3. 判断是否已连接到匹配的设备与资源
             device_state = self._worker.device_state
-            device_controller_name = device.get("controller_name")
+            device_controller_name = device.get("controller_name") or controller_name
             need_connect = True
             if (
                 device_state.connected
@@ -276,11 +276,11 @@ class SchedulerManager:
 
             # 4. 若配置已锁定但连接不匹配，先解锁
             if need_connect and device_state.configuration_locked:
-                await asyncio.to_thread(self._worker.devices.reset_connection_state)
+                await asyncio.to_thread(self._worker.device.reset_connection_state)
 
             # 5. 构造 DeviceModel 并重试连接
             if need_connect:
-                device_model = self._worker.devices.build_device_model_from_config(
+                device_model = self._worker.device.build_device_model_from_config(
                     device_controller_name,
                     device["device_type"],
                     device["device_address"],
@@ -293,12 +293,12 @@ class SchedulerManager:
                 for attempt in range(1, max_retry + 1):
                     try:
                         connected = await asyncio.to_thread(
-                            self._worker.devices.connect, device_model
+                            self._worker.device.connect, device_model
                         )
                         if not connected:
                             raise RuntimeError("connect() 返回 False")
                         resource_set = await asyncio.to_thread(
-                            self._worker.devices.set_resource, resource_name
+                            self._worker.device.set_resource, resource_name
                         )
                         if not resource_set:
                             raise RuntimeError("set_resource() 返回 False")
@@ -326,7 +326,7 @@ class SchedulerManager:
                         if _settings.notification.notifyOnError
                         else [],
                     )
-                    await asyncio.to_thread(self._worker.devices.reset_connection_state)
+                    await asyncio.to_thread(self._worker.device.reset_connection_state)
                     await self._update_execution_status(
                         execution_id, "failed", "设备连接失败"
                     )
@@ -737,24 +737,26 @@ class SchedulerManager:
                 else current_kwargs.get("preTasks", [])
                 or current_kwargs.get("pre_tasks", [])
             )
+            # Use model_fields_set to distinguish "field omitted" (keep current)
+            # from "field set to None" (explicitly clear).
+            updated_fields = task_update.model_fields_set
             new_controller_name = (
                 task_update.controller_name
-                if task_update.controller_name is not None
+                if "controller_name" in updated_fields
                 else current_kwargs.get("controller_name", None)
             )
-            new_device_raw = (
-                task_update.device
-                if task_update.device is not None
-                else current_kwargs.get("device", None)
-            )
-            new_device = (
-                new_device_raw.model_dump()
-                if isinstance(new_device_raw, BaseModel)
-                else new_device_raw
-            )
+            if "device" in updated_fields:
+                new_device_raw = task_update.device
+                new_device = (
+                    new_device_raw.model_dump()
+                    if isinstance(new_device_raw, BaseModel)
+                    else new_device_raw
+                )
+            else:
+                new_device = current_kwargs.get("device", None)
             new_resource_name = (
                 task_update.resource_name
-                if task_update.resource_name is not None
+                if "resource_name" in updated_fields
                 else current_kwargs.get("resource_name", None)
             )
             normalized_task_list, normalized_task_options, normalized_pre_tasks = (


### PR DESCRIPTION
This pull request significantly improves the device and resource selection experience in the panel, enhances i18n support, and simplifies the connection workflow. The main changes include a more flexible device selection dropdown, improved recent/discovered device handling, and a streamlined connection process that ensures devices and resources are properly set before starting a task. Additionally, several UI and i18n improvements were made.

**Device and Resource Selection Improvements:**
* The device dropdown in `PanelConnectionTabs.vue` now supports filtering, custom input, and clearable selection, and displays devices grouped as "Recent" and "Discovered" using improved logic for building device options. [[1]](diffhunk://#diff-7d7d230e247b084bf1e410098e02f8328fbcabfccaef267c9bf686e1f7915e95R30-R43) [[2]](diffhunk://#diff-c8b0f2db522a18853d994fdc2098f51a593e9a8576317d703bb3cd355ad4b6dcL130-R292)
* Recent devices are tracked and shown only if they are not currently discovered, and custom device addresses are supported.
* The resource dropdown is now clearable and no longer emits unnecessary events; resource fetching and confirmation are handled programmatically. [[1]](diffhunk://#diff-7d7d230e247b084bf1e410098e02f8328fbcabfccaef267c9bf686e1f7915e95L53-L67) [[2]](diffhunk://#diff-7d7d230e247b084bf1e410098e02f8328fbcabfccaef267c9bf686e1f7915e95L99-L101)

**Connection Workflow Enhancements:**
* The connection process (`connectDevices` and `postResourceSelection`) now returns structured results, provides better error handling, and integrates with a new global message system for user feedback. [[1]](diffhunk://#diff-c8b0f2db522a18853d994fdc2098f51a593e9a8576317d703bb3cd355ad4b6dcL381-R610) [[2]](diffhunk://#diff-c8b0f2db522a18853d994fdc2098f51a593e9a8576317d703bb3cd355ad4b6dcL497-R669) [[3]](diffhunk://#diff-c8b0f2db522a18853d994fdc2098f51a593e9a8576317d703bb3cd355ad4b6dcL511-R685)
* Starting a task automatically ensures the device and resource are connected and set, improving reliability and user experience.

**Internationalization (i18n):**
* Added new i18n keys for device and resource selection, recent/discovered devices, and refresh actions in both English and Chinese. [[1]](diffhunk://#diff-96069c3109ed10641088e231d4ec636e5fc89a7db5d0be241944d0abd6c7a77fL145-R149) [[2]](diffhunk://#diff-96069c3109ed10641088e231d4ec636e5fc89a7db5d0be241944d0abd6c7a77fR214-R221) [[3]](diffhunk://#diff-e2704500a5e910758790e0533a7aad389a58cca15dbba0eb8a074f294de520b9L145-R149) [[4]](diffhunk://#diff-e2704500a5e910758790e0533a7aad389a58cca15dbba0eb8a074f294de520b9R214-R221)

**Codebase Simplification and Refactoring:**
* Removed unused emits and redundant button elements, and refactored device/resource selection logic for clarity and maintainability. [[1]](diffhunk://#diff-7d7d230e247b084bf1e410098e02f8328fbcabfccaef267c9bf686e1f7915e95L99-L101) [[2]](diffhunk://#diff-7d7d230e247b084bf1e410098e02f8328fbcabfccaef267c9bf686e1f7915e95L53-L67) [[3]](diffhunk://#diff-c8b0f2db522a18853d994fdc2098f51a593e9a8576317d703bb3cd355ad4b6dcL22)
* Improved typing and code structure for device/resource handling, and added helper functions for device building and labeling. [[1]](diffhunk://#diff-c8b0f2db522a18853d994fdc2098f51a593e9a8576317d703bb3cd355ad4b6dcL130-R292) [[2]](diffhunk://#diff-c8b0f2db522a18853d994fdc2098f51a593e9a8576317d703bb3cd355ad4b6dcL46-R45) [[3]](diffhunk://#diff-c8b0f2db522a18853d994fdc2098f51a593e9a8576317d703bb3cd355ad4b6dcR60-R64)

**UI/UX Improvements:**
* The device and resource dropdowns are now more responsive to controller changes, and the UI disables options appropriately based on connection state. [[1]](diffhunk://#diff-c8b0f2db522a18853d994fdc2098f51a593e9a8576317d703bb3cd355ad4b6dcL130-R292) [[2]](diffhunk://#diff-c8b0f2db522a18853d994fdc2098f51a593e9a8576317d703bb3cd355ad4b6dcR453-R454) [[3]](diffhunk://#diff-c8b0f2db522a18853d994fdc2098f51a593e9a8576317d703bb3cd355ad4b6dcR508-R517)

These changes collectively make the device/resource selection process more robust, user-friendly, and maintainable.

## Summary by Sourcery

在面板和调度器中重构设备和资源选择逻辑，以支持类型化设备配置、最近/已发现设备选项，以及在任务执行前的自动连接/设置，同时使后端调度器和资源 API 与新的工作流程保持一致。

新特性：
- 在调度器侧添加设备和资源配置，使定时任务能够存储控制器、设备和资源设置，并在运行前自动连接。
- 在面板的设备/资源选择器中支持分组展示的最近和已发现设备、自定义设备地址，以及基于控制器的资源列表。

缺陷修复：
- 通过在资源 API 中暴露控制器类型过滤，确保即使设备尚未连接，也能获取并选择资源。
- 修复任务启动逻辑，确保任务只在兼容的设备和资源已连接时才运行，否则尽早失败并给出清晰的反馈。

增强改进：
- 精简面板连接标签页的 UI，使设备和资源选择器支持清空、过滤，并由程序化的获取/连接流程驱动，而不再依赖显式的确认按钮。
- 引入全局的基于消息的反馈，用于设备/资源连接错误和任务兼容性问题。
- 添加辅助工具和设置存储支持，用于管理最近连接和最后连接的设备，包括截断和持久化。

文档：
- 扩展设备/资源选择、最近/已发现设备以及刷新操作相关的 i18n 文案，覆盖英文和中文。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor device and resource selection across the panel and scheduler to support typed device configs, recent/discovered device options, and automatic connection/setup before task execution, while aligning backend scheduler and resource APIs with the new workflow.

New Features:
- Add scheduler-side device and resource configuration so timed tasks store controller, device, and resource settings and auto-connect before running.
- Support grouped recent and discovered devices, custom device addresses, and controller-specific resource lists in the panel device/resource selectors.

Bug Fixes:
- Ensure resources can be fetched and selected even when devices are not yet connected by exposing controller-type filtering on the resource API.
- Fix task start logic so tasks only run when a compatible device and resource are connected, otherwise failing early with clear feedback.

Enhancements:
- Streamline panel connection tabs UI by making device and resource selects clearable, filterable, and driven by programmatic fetch/connect flows instead of explicit confirm buttons.
- Introduce global message-based feedback for device/resource connection errors and task compatibility issues.
- Add helper utilities and settings store support for managing last and recent connected devices, including truncation and persistence.

Documentation:
- Extend i18n messages for device/resource selection, recent/discovered devices, and refresh actions in both English and Chinese.

</details>